### PR TITLE
Use static directory in Python directory tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,8 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
-static/
+src/*/static/*
+!src/*/static/.gitkeep
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build --outDir ../static --emptyOutDir",
+    "build": "tsc -b && vite build --outDir ../src/fmu_settings_gui/static --emptyOutDir",
     "lint": "tools/biome check src && eslint .",
     "preview": "vite preview"
   },

--- a/src/fmu_settings_gui/__main__.py
+++ b/src/fmu_settings_gui/__main__.py
@@ -10,7 +10,7 @@ from fastapi.staticfiles import StaticFiles
 app = FastAPI(title="FMU Settings GUI")
 
 current_dir = Path(__file__).parent.absolute()
-static_dir = current_dir.parent.parent / "static"
+static_dir = current_dir / "static"
 
 app.mount("/", StaticFiles(directory=str(static_dir), html=True), name="static")
 


### PR DESCRIPTION
Resolves #7 

The `static` directory, for the built React application files, is now placed in `src/fmu_settings_gui`. Also, ensure the directory exists in package, even when no regular files are there. This is a temporary solution until the build and package process is properly set up.

## Checklist

- [X] Tests added - not relevant
- [ ] Test coverage equal or up from main (run pytest with `--cov=<packagename> --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
