### PR TITLE
Create session on unauthorized mutation

### DIFF
--- a/frontend/src/components/form.tsx
+++ b/frontend/src/components/form.tsx
@@ -137,6 +137,11 @@ export function EditableTextFieldForm({
   const { data } = useSuspenseQuery(v1GetUserOptions());
   const { mutate, isPending } = useMutation({
     ...v1PatchApiKeyMutation(),
+    onSuccess: () => {
+      void queryClient.refetchQueries({
+        queryKey: v1GetUserQueryKey(),
+      });
+    },
     retry: (failureCount, error) => queryMutationRetry(failureCount, error),
     meta: { errorPrefix: "Error updating API key" },
   });
@@ -168,9 +173,6 @@ export function EditableTextFieldForm({
         {
           onSuccess: (data) => {
             toast.info(data.message);
-            void queryClient.refetchQueries({
-              queryKey: v1GetUserQueryKey(),
-            });
             formApi.reset();
             setIsReadonly(true);
           },

--- a/frontend/src/components/form.tsx
+++ b/frontend/src/components/form.tsx
@@ -28,6 +28,7 @@ import {
   v1GetUserQueryKey,
   v1PatchApiKeyMutation,
 } from "../client/@tanstack/react-query.gen";
+import { queryMutationRetry } from "../utils/authentication";
 import { fieldContext, formContext, useFieldContext } from "../utils/form";
 import { EditableTextFieldFormContainer } from "./form.style";
 
@@ -136,7 +137,8 @@ export function EditableTextFieldForm({
   const { data } = useSuspenseQuery(v1GetUserOptions());
   const { mutate, isPending } = useMutation({
     ...v1PatchApiKeyMutation(),
-    meta: { errorMessage: "Error updating API key" },
+    retry: (failureCount, error) => queryMutationRetry(failureCount, error),
+    meta: { errorPrefix: "Error updating API key" },
   });
 
   let validator: ZodString | undefined;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -51,13 +51,14 @@ declare module "@tanstack/react-router" {
   }
 }
 
-interface QueryMeta extends Record<string, unknown> {
-  errorMessage?: string;
+interface QueryMutationMeta extends Record<string, unknown> {
+  errorPrefix?: string;
 }
 
 declare module "@tanstack/react-query" {
   interface Register {
-    queryMeta: QueryMeta;
+    queryMeta: QueryMutationMeta;
+    mutationMeta: QueryMutationMeta;
   }
 }
 
@@ -66,8 +67,8 @@ const queryClient = new QueryClient({
     onError: (error, query) => {
       const message =
         `${
-          query.meta && "errorMessage" in query.meta
-            ? String(query.meta.errorMessage)
+          query.meta && "errorPrefix" in query.meta
+            ? String(query.meta.errorPrefix)
             : "Error getting data"
         }: ` +
         (isAxiosError(error) &&
@@ -84,8 +85,8 @@ const queryClient = new QueryClient({
     onError: (error, _variables, _context, mutation) => {
       const message =
         `${
-          mutation.meta && "errorMessage" in mutation.meta
-            ? String(mutation.meta.errorMessage)
+          mutation.meta && "errorPrefix" in mutation.meta
+            ? String(mutation.meta.errorPrefix)
             : "Error updating data"
         }: ` +
         (isAxiosError(error) &&
@@ -130,11 +131,7 @@ export function App() {
     useState<boolean>(false);
   const { mutateAsync: createSessionMutateAsync } = useMutation({
     ...v1CreateSessionMutation(),
-    onError: (error) => {
-      const message = "Error creating session: " + error.message;
-      console.error(message);
-      toast.error(message);
-    },
+    meta: { errorPrefix: "Error creating session" },
   });
 
   useEffect(() => {

--- a/frontend/src/utils/authentication.ts
+++ b/frontend/src/utils/authentication.ts
@@ -1,5 +1,5 @@
 import { UseMutateAsyncFunction } from "@tanstack/react-query";
-import { AxiosError, AxiosResponse } from "axios";
+import { AxiosError, AxiosResponse, isAxiosError } from "axios";
 import { Dispatch, SetStateAction } from "react";
 
 import { Message, Options, V1CreateSessionData } from "../client";
@@ -117,3 +117,16 @@ export const responseInterceptorRejected =
     }
     return Promise.reject(error);
   };
+
+export const queryMutationRetry = (failureCount: number, error: Error) => {
+  if (
+    isAxiosError(error) &&
+    isApiUrlSession(error.response?.config.url) &&
+    error.status === 401
+  ) {
+    // Don't retry query if it resulted in a failed session creation
+    return false;
+  }
+  // Specify at most 2 retries
+  return failureCount < 2;
+};


### PR DESCRIPTION
Resolves #30

Mutations (the storing of data) can now be defined with a retry function. If a mutation fails with a 401 Unauthorized response from the API, a new session will automatically be created due to the Axios interceptor. This has already been the case, but with thisPR a mutation can be defined to retry, so that it will succeed as the new session cookie will be used.

Also, error reporting (toast and console logging) when a session creation fails has been reduced, so that only one message for the failed session creation is reported and not two. There will also be an error report for the query or mutation that failed, resulting in two reports in all.

Some minor refactoring has also been done.

## Checklist

- [ ] Tests added - not relevant
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
