### PR TITLE
MAINT: Have query/mutation and form logic separate

### DIFF
--- a/frontend/src/components/form.tsx
+++ b/frontend/src/components/form.tsx
@@ -8,11 +8,6 @@ import {
 import { error_filled } from "@equinor/eds-icons";
 import { createFormHook } from "@tanstack/react-form";
 import {
-  QueryClient,
-  useMutation,
-  useSuspenseQuery,
-} from "@tanstack/react-query";
-import {
   ChangeEvent,
   Dispatch,
   SetStateAction,
@@ -22,17 +17,37 @@ import {
 import { toast } from "react-toastify";
 import z, { ZodString } from "zod/v4";
 
-import { UserApiKeys } from "../client";
-import {
-  v1GetUserOptions,
-  v1GetUserQueryKey,
-  v1PatchApiKeyMutation,
-} from "../client/@tanstack/react-query.gen";
-import { queryMutationRetry } from "../utils/authentication";
 import { fieldContext, formContext, useFieldContext } from "../utils/form";
 import { EditableTextFieldFormContainer } from "./form.style";
 
 Icon.add({ error_filled });
+
+export type StringObject = { [x: string]: string };
+
+interface FormSubmitCallbackProps {
+  message: string;
+  formReset: () => void;
+}
+
+export interface MutationCallbackProps<T> {
+  formValue: T;
+  formSubmitCallback: (props: FormSubmitCallbackProps) => void;
+  formReset: () => void;
+}
+
+export interface CommonTextFieldFormProps {
+  name: string;
+  label: string;
+  value: string;
+  placeholder?: string;
+  length?: number;
+  minLength?: number;
+}
+
+interface MutationFormProps {
+  mutationCallback: (props: MutationCallbackProps<StringObject>) => void;
+  mutationIsPending: boolean;
+}
 
 export function TextField({
   label,
@@ -117,67 +132,55 @@ const { useAppForm: useAppFormEditableTextField } = createFormHook({
   formComponents: { SubmitButton },
 });
 
+type EditableTextFieldFormProps = CommonTextFieldFormProps & MutationFormProps;
+
 export function EditableTextFieldForm({
-  apiKey,
+  name,
   label,
-  queryClient,
+  value,
+  mutationCallback,
+  mutationIsPending,
   placeholder,
   length,
   minLength,
-}: {
-  apiKey: keyof UserApiKeys;
-  label: string;
-  queryClient: QueryClient;
-  placeholder?: string;
-  length?: number;
-  minLength?: number;
-}) {
+}: EditableTextFieldFormProps) {
   const [isReadonly, setIsReadonly] = useState(true);
   const [submitDisabled, setSubmitDisabled] = useState(true);
-  const { data } = useSuspenseQuery(v1GetUserOptions());
-  const { mutate, isPending } = useMutation({
-    ...v1PatchApiKeyMutation(),
-    onSuccess: () => {
-      void queryClient.refetchQueries({
-        queryKey: v1GetUserQueryKey(),
-      });
-    },
-    retry: (failureCount, error) => queryMutationRetry(failureCount, error),
-    meta: { errorPrefix: "Error updating API key" },
-  });
 
   let validator: ZodString | undefined;
   if (length !== undefined) {
     validator = z
       .string()
       .refine((val: string) => val === "" || val.length === length, {
-        error: `Value must be exactly ${String(length)} characters long`,
+        error: `Value must be empty or exactly ${String(length)} characters long`,
       });
   } else if (minLength !== undefined) {
     validator = z
       .string()
       .refine((val) => val === "" || val.length >= minLength, {
-        error: `Value must be at least ${String(minLength)} characters long`,
+        error: `Value must be empty or at least ${String(minLength)} characters long`,
       });
   }
 
+  const formSubmitCallback = ({
+    message,
+    formReset,
+  }: FormSubmitCallbackProps) => {
+    toast.info(message);
+    formReset();
+    setIsReadonly(true);
+  };
+
   const form = useAppFormEditableTextField({
     defaultValues: {
-      [apiKey]: data.user_api_keys[apiKey] ?? "",
+      [name]: value,
     },
     onSubmit: ({ formApi, value }) => {
-      mutate(
-        {
-          body: { id: apiKey, key: value[apiKey] },
-        },
-        {
-          onSuccess: (data) => {
-            toast.info(data.message);
-            formApi.reset();
-            setIsReadonly(true);
-          },
-        },
-      );
+      mutationCallback({
+        formValue: value,
+        formSubmitCallback,
+        formReset: formApi.reset,
+      });
     },
   });
 
@@ -191,7 +194,7 @@ export function EditableTextFieldForm({
         }}
       >
         <form.AppField
-          name={apiKey}
+          name={name}
           {...(validator && {
             validators: {
               onBlur: validator,
@@ -221,7 +224,7 @@ export function EditableTextFieldForm({
             <>
               <form.SubmitButton
                 disabled={submitDisabled}
-                isPending={isPending}
+                isPending={mutationIsPending}
               />
               <Button
                 type="reset"

--- a/frontend/src/components/form.tsx
+++ b/frontend/src/components/form.tsx
@@ -138,11 +138,11 @@ export function EditableTextFieldForm({
   name,
   label,
   value,
-  mutationCallback,
-  mutationIsPending,
   placeholder,
   length,
   minLength,
+  mutationCallback,
+  mutationIsPending,
 }: EditableTextFieldFormProps) {
   const [isReadonly, setIsReadonly] = useState(true);
   const [submitDisabled, setSubmitDisabled] = useState(true);

--- a/frontend/src/routes/user/keys.style.ts
+++ b/frontend/src/routes/user/keys.style.ts
@@ -1,5 +1,5 @@
 import styled from "styled-components";
 
-export const KeysForm = styled.div`
+export const KeysFormContainer = styled.div`
   width: 24em;
 `;

--- a/frontend/src/routes/user/keys.tsx
+++ b/frontend/src/routes/user/keys.tsx
@@ -1,15 +1,95 @@
 import { Typography } from "@equinor/eds-core-react";
+import {
+  QueryClient,
+  useMutation,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { Suspense } from "react";
 
+import { UserApiKeys } from "../../client";
+import {
+  v1GetUserOptions,
+  v1GetUserQueryKey,
+  v1PatchApiKeyMutation,
+} from "../../client/@tanstack/react-query.gen";
 import { Loading } from "../../components/common";
-import { EditableTextFieldForm } from "../../components/form";
+import {
+  CommonTextFieldFormProps,
+  EditableTextFieldForm,
+  MutationCallbackProps,
+  StringObject,
+} from "../../components/form";
 import { PageHeader, PageSectionSpacer, PageText } from "../../styles/common";
+import { queryMutationRetry } from "../../utils/authentication";
 import { KeysForm } from "./keys.style";
 
 export const Route = createFileRoute("/user/keys")({
   component: RouteComponent,
 });
+
+type KeysTextFieldFormProps = Omit<
+  CommonTextFieldFormProps,
+  "name" | "value"
+> & {
+  apiKey: keyof UserApiKeys;
+  queryClient: QueryClient;
+};
+
+function KeysTextFieldForm({
+  apiKey,
+  label,
+  queryClient,
+  placeholder,
+  length,
+  minLength,
+}: KeysTextFieldFormProps) {
+  const { data } = useSuspenseQuery(v1GetUserOptions());
+  const { mutate, isPending } = useMutation({
+    ...v1PatchApiKeyMutation(),
+    onSuccess: () => {
+      void queryClient.refetchQueries({
+        queryKey: v1GetUserQueryKey(),
+      });
+    },
+    retry: (failureCount: number, error: Error) =>
+      queryMutationRetry(failureCount, error),
+    meta: { errorPrefix: "Error updating API key" },
+  });
+
+  const name = String(apiKey);
+
+  const mutationCallback = ({
+    formValue,
+    formSubmitCallback,
+    formReset,
+  }: MutationCallbackProps<StringObject>) => {
+    mutate(
+      { body: { id: name, key: formValue[name] } },
+      {
+        onSuccess: (data) => {
+          formSubmitCallback({
+            message: data.message,
+            formReset,
+          });
+        },
+      },
+    );
+  };
+
+  return (
+    <EditableTextFieldForm
+      name={name}
+      label={label}
+      value={data.user_api_keys[apiKey] ?? ""}
+      mutationCallback={mutationCallback}
+      mutationIsPending={isPending}
+      placeholder={placeholder}
+      length={length}
+      minLength={minLength}
+    />
+  );
+}
 
 function Content() {
   const { queryClient } = Route.useRouteContext();
@@ -62,7 +142,7 @@ function Content() {
       <PageSectionSpacer />
 
       <KeysForm>
-        <EditableTextFieldForm
+        <KeysTextFieldForm
           apiKey="smda_subscription"
           label="SMDA subscription primary key"
           queryClient={queryClient}

--- a/frontend/src/routes/user/keys.tsx
+++ b/frontend/src/routes/user/keys.tsx
@@ -22,7 +22,7 @@ import {
 } from "../../components/form";
 import { PageHeader, PageSectionSpacer, PageText } from "../../styles/common";
 import { queryMutationRetry } from "../../utils/authentication";
-import { KeysForm } from "./keys.style";
+import { KeysFormContainer } from "./keys.style";
 
 export const Route = createFileRoute("/user/keys")({
   component: RouteComponent,
@@ -82,11 +82,11 @@ function KeysTextFieldForm({
       name={name}
       label={label}
       value={data.user_api_keys[apiKey] ?? ""}
-      mutationCallback={mutationCallback}
-      mutationIsPending={isPending}
       placeholder={placeholder}
       length={length}
       minLength={minLength}
+      mutationCallback={mutationCallback}
+      mutationIsPending={isPending}
     />
   );
 }
@@ -141,15 +141,15 @@ function Content() {
 
       <PageSectionSpacer />
 
-      <KeysForm>
+      <KeysFormContainer>
         <KeysTextFieldForm
           apiKey="smda_subscription"
           label="SMDA subscription primary key"
-          queryClient={queryClient}
           placeholder="(not set)"
           length={32}
+          queryClient={queryClient}
         />
-      </KeysForm>
+      </KeysFormContainer>
     </>
   );
 }

--- a/frontend/src/utils/authentication.ts
+++ b/frontend/src/utils/authentication.ts
@@ -57,7 +57,7 @@ export function isApiTokenNonEmpty(apiToken: string): boolean {
   return apiToken !== "";
 }
 
-export function isApiUrlSession(url?: string): boolean {
+function isApiUrlSession(url?: string): boolean {
   return url === APIURL_SESSION;
 }
 
@@ -124,7 +124,7 @@ export const queryMutationRetry = (failureCount: number, error: Error) => {
     isApiUrlSession(error.response?.config.url) &&
     error.status === 401
   ) {
-    // Don't retry query if it resulted in a failed session creation
+    // Don't retry query or mutation if it resulted in a failed session creation
     return false;
   }
   // Specify at most 2 retries


### PR DESCRIPTION
Resolves #32

Adds a component `KeysTextFieldForm` for setting up data query and mutation, which uses the `EditableTextFieldForm` for form logic. Uses some callback functions to let the two major operations do the necessary logic.

When the user submits the form, the following happens:
1. The form's `onSubmit` function executes, which calls the `mutationCallback` defined in the query/mutation component
2. The `mutationCallback` function executes, which performs the mutation (saving of data to the API). A successful mutation will call the `formSubmitCallback` function, defined in the form component
3. The `formSubmitCallback` function executes, which will show a toast message to the user and reset the form, so that the form will show the updated value
4. If the mutation results in an error, a toast error message will be shown to the user. This is handled by the default error handling of the query/mutation client

See also description on some of the code in the files.


## Checklist

- [X] Tests added - not relevant
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
