### PR TITLE
ENH: Don't trigger session creation on unauthorized API response from external API

### DIFF
--- a/frontend/src/utils/authentication.ts
+++ b/frontend/src/utils/authentication.ts
@@ -61,6 +61,10 @@ function isApiUrlSession(url?: string): boolean {
   return url === APIURL_SESSION;
 }
 
+function isExternalApi(source?: string): boolean {
+  return source === "SMDA";
+}
+
 async function createSessionAsync(
   createSessionMutateAsync: UseMutateAsyncFunction<
     Message,
@@ -111,7 +115,9 @@ export const responseInterceptorRejected =
         if (apiTokenStatusValid) {
           setApiTokenStatus(() => ({}));
         }
-      } else {
+      } else if (
+        !isExternalApi(String(error.response?.headers["x-upstream-source"]))
+      ) {
         await createSessionAsync(createSessionMutateAsync, apiToken);
       }
     }


### PR DESCRIPTION
Resolves #23 

When an API response has a 401 Unauthorized status code, don't trigger a session creation when the response is marked as having an upstream source. Currently only the source "SMDA" is used by the local API.

## Checklist

- [X] Tests added - not relevant
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
