### PR TITLE
Rewrite SPA internal paths in the API to the GUI

### DIFF
--- a/src/fmu_settings_gui/__main__.py
+++ b/src/fmu_settings_gui/__main__.py
@@ -24,10 +24,12 @@ async def serve_spa_catchall(full_path: str) -> FileResponse:
     """Ensures internal paths to the GUI are served by the SPA."""
     if full_path == "":
         full_path = "index.html"
-    resolved_path = os.path.normpath(os.path.realpath(static_dir / Path(full_path)))
+    resolved_path = os.path.normpath(
+        os.path.realpath(os.path.join(str(static_dir), full_path))
+    )
     if bool(re.fullmatch(r"^[\w\s\.\-/]+$", str(resolved_path))) is False:
         raise ValueError(f"Unallowed characters present in {full_path!r}")
-    if not Path(os.path.commonprefix((static_dir, resolved_path))) == static_dir:
+    if not os.path.commonprefix((static_dir, resolved_path)) == str(static_dir):
         raise HTTPException(status_code=403, detail="Access denied")
     if os.path.exists(resolved_path):
         return FileResponse(resolved_path)

--- a/src/fmu_settings_gui/__main__.py
+++ b/src/fmu_settings_gui/__main__.py
@@ -23,7 +23,9 @@ async def serve_spa_catchall(full_path: str) -> FileResponse:
     """Ensures internal paths to the GUI are served by the SPA."""
     if full_path == "":
         full_path = "index.html"
-    resolved_path = Path(os.path.normpath(static_dir / Path(full_path)))
+    resolved_path = Path(
+        os.path.normpath(os.path.realpath(static_dir / Path(full_path)))
+    )
     if not Path(os.path.commonprefix((static_dir, resolved_path))) == static_dir:
         raise HTTPException(status_code=403, detail="Access denied")
     if resolved_path.exists():

--- a/src/fmu_settings_gui/__main__.py
+++ b/src/fmu_settings_gui/__main__.py
@@ -16,14 +16,16 @@ app = FastAPI(title="FMU Settings GUI")
 current_dir = Path(__file__).parent.absolute()
 static_dir = current_dir / "static"
 
+
 @app.get("/{full_path:path}")
-async def serve_spa_catchall(full_path: str):
+async def serve_spa_catchall(full_path: str) -> FileResponse:
     """Ensures internal paths to the GUI are served by the SPA."""
     if full_path == "":
         full_path = "index.html"
     if Path(static_dir / full_path).exists():
         return FileResponse(Path(static_dir / full_path))
     return FileResponse(static_dir / "index.html")
+
 
 app.mount("/", StaticFiles(directory=str(static_dir), html=True), name="static")
 

--- a/src/fmu_settings_gui/__main__.py
+++ b/src/fmu_settings_gui/__main__.py
@@ -24,14 +24,12 @@ async def serve_spa_catchall(full_path: str) -> FileResponse:
     """Ensures internal paths to the GUI are served by the SPA."""
     if full_path == "":
         full_path = "index.html"
-    resolved_path = Path(
-        os.path.normpath(os.path.realpath(static_dir / Path(full_path)))
-    )
+    resolved_path = os.path.normpath(os.path.realpath(static_dir / Path(full_path)))
     if bool(re.fullmatch(r"^[\w\s\.\-/]+$", str(resolved_path))) is False:
         raise ValueError(f"Unallowed characters present in {full_path!r}")
     if not Path(os.path.commonprefix((static_dir, resolved_path))) == static_dir:
         raise HTTPException(status_code=403, detail="Access denied")
-    if resolved_path.exists():
+    if os.path.exists(resolved_path):
         return FileResponse(resolved_path)
     return FileResponse(static_dir / "index.html")
 

--- a/src/fmu_settings_gui/__main__.py
+++ b/src/fmu_settings_gui/__main__.py
@@ -23,7 +23,7 @@ async def serve_spa_catchall(full_path: str) -> FileResponse:
     """Ensures internal paths to the GUI are served by the SPA."""
     if full_path == "":
         full_path = "index.html"
-    resolved_path = Path(static_dir / Path(full_path)).resolve()
+    resolved_path = Path(os.path.normpath(static_dir / Path(full_path)))
     if not Path(os.path.commonprefix((static_dir, resolved_path))) == static_dir:
         raise HTTPException(status_code=403, detail="Access denied")
     if resolved_path.exists():

--- a/src/fmu_settings_gui/__main__.py
+++ b/src/fmu_settings_gui/__main__.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import os
+import re
 import signal
 import sys
 from pathlib import Path
@@ -26,6 +27,8 @@ async def serve_spa_catchall(full_path: str) -> FileResponse:
     resolved_path = Path(
         os.path.normpath(os.path.realpath(static_dir / Path(full_path)))
     )
+    if bool(re.fullmatch(r"^[\w\s\.\-/]+$", resolved_path)) is False:
+        raise ValueError(f"Unallowed characters present in {full_path!r}")
     if not Path(os.path.commonprefix((static_dir, resolved_path))) == static_dir:
         raise HTTPException(status_code=403, detail="Access denied")
     if resolved_path.exists():

--- a/src/fmu_settings_gui/__main__.py
+++ b/src/fmu_settings_gui/__main__.py
@@ -29,7 +29,7 @@ async def serve_spa_catchall(full_path: str) -> FileResponse:
     )
     if bool(re.fullmatch(r"^[\w\s\.\-/]+$", str(resolved_path))) is False:
         raise ValueError(f"Unallowed characters present in {full_path!r}")
-    if not os.path.commonprefix((static_dir, resolved_path)) == str(static_dir):
+    if not resolved_path.startswith(str(static_dir)):
         raise HTTPException(status_code=403, detail="Access denied")
     if os.path.exists(resolved_path):
         return FileResponse(resolved_path)

--- a/src/fmu_settings_gui/__main__.py
+++ b/src/fmu_settings_gui/__main__.py
@@ -1,6 +1,8 @@
 """The main entry point for fmu-settings-gui."""
 
 import asyncio
+import os
+import re
 import signal
 import sys
 from pathlib import Path
@@ -22,10 +24,14 @@ async def serve_spa_catchall(full_path: str) -> FileResponse:
     """Ensures internal paths to the GUI are served by the SPA."""
     if full_path == "":
         full_path = "index.html"
-    resolved_path = Path(static_dir / Path(full_path)).resolve()
-    if not str(resolved_path).startswith(str(static_dir)):
+    resolved_path = os.path.normpath(
+        os.path.realpath(os.path.join(str(static_dir), full_path))
+    )
+    if bool(re.fullmatch(r"^[\w\s\.\-/]+$", str(resolved_path))) is False:
+        raise ValueError(f"Unallowed characters present in {full_path!r}")
+    if not resolved_path.startswith(str(static_dir)):
         raise HTTPException(status_code=403, detail="Access denied")
-    if resolved_path.exists():
+    if os.path.exists(resolved_path):
         return FileResponse(resolved_path)
     return FileResponse(static_dir / "index.html")
 

--- a/src/fmu_settings_gui/__main__.py
+++ b/src/fmu_settings_gui/__main__.py
@@ -26,8 +26,8 @@ async def serve_spa_catchall(full_path: str) -> FileResponse:
     resolved_path = Path(static_dir / Path(full_path)).resolve()
     if not Path(os.path.commonprefix((static_dir, resolved_path))) == static_dir:
         raise HTTPException(status_code=403, detail="Access denied")
-    if Path(static_dir / full_path).exists():
-        return FileResponse(Path(static_dir / full_path))
+    if resolved_path.exists():
+        return FileResponse(resolved_path)
     return FileResponse(static_dir / "index.html")
 
 

--- a/src/fmu_settings_gui/__main__.py
+++ b/src/fmu_settings_gui/__main__.py
@@ -1,13 +1,14 @@
 """The main entry point for fmu-settings-gui."""
 
 import asyncio
+import os
 import signal
 import sys
 from pathlib import Path
 from types import FrameType
 
 import uvicorn
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from starlette.responses import FileResponse
 
@@ -22,6 +23,9 @@ async def serve_spa_catchall(full_path: str) -> FileResponse:
     """Ensures internal paths to the GUI are served by the SPA."""
     if full_path == "":
         full_path = "index.html"
+    resolved_path = Path(static_dir / Path(full_path)).resolve()
+    if not Path(os.path.commonprefix((static_dir, resolved_path))) == static_dir:
+        raise HTTPException(status_code=403, detail="Access denied")
     if Path(static_dir / full_path).exists():
         return FileResponse(Path(static_dir / full_path))
     return FileResponse(static_dir / "index.html")

--- a/src/fmu_settings_gui/__main__.py
+++ b/src/fmu_settings_gui/__main__.py
@@ -1,8 +1,6 @@
 """The main entry point for fmu-settings-gui."""
 
 import asyncio
-import os
-import re
 import signal
 import sys
 from pathlib import Path
@@ -24,14 +22,10 @@ async def serve_spa_catchall(full_path: str) -> FileResponse:
     """Ensures internal paths to the GUI are served by the SPA."""
     if full_path == "":
         full_path = "index.html"
-    resolved_path = os.path.normpath(
-        os.path.realpath(os.path.join(str(static_dir), full_path))
-    )
-    if bool(re.fullmatch(r"^[\w\s\.\-/]+$", str(resolved_path))) is False:
-        raise ValueError(f"Unallowed characters present in {full_path!r}")
-    if not resolved_path.startswith(str(static_dir)):
+    resolved_path = Path(static_dir / Path(full_path)).resolve()
+    if not str(resolved_path).startswith(str(static_dir)):
         raise HTTPException(status_code=403, detail="Access denied")
-    if os.path.exists(resolved_path):
+    if resolved_path.exists():
         return FileResponse(resolved_path)
     return FileResponse(static_dir / "index.html")
 

--- a/src/fmu_settings_gui/__main__.py
+++ b/src/fmu_settings_gui/__main__.py
@@ -27,7 +27,7 @@ async def serve_spa_catchall(full_path: str) -> FileResponse:
     resolved_path = Path(
         os.path.normpath(os.path.realpath(static_dir / Path(full_path)))
     )
-    if bool(re.fullmatch(r"^[\w\s\.\-/]+$", resolved_path)) is False:
+    if bool(re.fullmatch(r"^[\w\s\.\-/]+$", str(resolved_path))) is False:
         raise ValueError(f"Unallowed characters present in {full_path!r}")
     if not Path(os.path.commonprefix((static_dir, resolved_path))) == static_dir:
         raise HTTPException(status_code=403, detail="Access denied")

--- a/src/fmu_settings_gui/__main__.py
+++ b/src/fmu_settings_gui/__main__.py
@@ -9,11 +9,21 @@ from types import FrameType
 import uvicorn
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
+from starlette.responses import FileResponse
 
 app = FastAPI(title="FMU Settings GUI")
 
 current_dir = Path(__file__).parent.absolute()
 static_dir = current_dir / "static"
+
+@app.get("/{full_path:path}")
+async def serve_spa_catchall(full_path: str):
+    """Ensures internal paths to the GUI are served by the SPA."""
+    if full_path == "":
+        full_path = "index.html"
+    if Path(static_dir / full_path).exists():
+        return FileResponse(Path(static_dir / full_path))
+    return FileResponse(static_dir / "index.html")
 
 app.mount("/", StaticFiles(directory=str(static_dir), html=True), name="static")
 


### PR DESCRIPTION
Resolves #40 

The behaviour happens for any URL that is visited outside of the SPA, such as when entering a subpath (like /general/smda) in a new browser window. It is thus not unique to the MSAL, but observed during the login process as redirects are being made away from the SPA and then back to a specific SPA page, which is a subpath.

The solution is to configure the FastAPI serving the SPA to rewrite any paths that are not for the static files (the SPA assets) so that they serve the initial index.html file. When this file is loaded in the browser, the SPA will recognise the subpath and show the correct page.

## Checklist

- [ ] Tests added - not relevant
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
