### PR TITLE
Use path aliases

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -30,7 +30,18 @@
     "enabled": true,
     "actions": {
       "source": {
-        "organizeImports": "on"
+        "organizeImports": {
+          "level": "on",
+          "options": {
+            "groups": [
+              ":PACKAGE:",
+              ":BLANK_LINE:",
+              ":ALIAS:",
+              ":PATH:"
+            ]
+
+          }
+        }
       }
     }
   }

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -135,7 +135,7 @@ tracked and needs to be commited.
 The codebase is configured to use path aliases, to more easily arrange imports and to
 avoid excessive levels of relative directories in imports. The code is structured in a
 handful of main subdirectories, like components, routes and utils. There are path aliases
-configured for these subdiretories, which are named prefixed with `#` (ie.
+configured for these subdirectories, which are named prefixed with `#` (ie.
 `#components`). These path aliases are defined in the
 [tsconfig.app.json](tsconfig.app.json) file, and should rarely need to be updated or
 added to. Editors like Visual Studio Code should be able to deal naturally with these

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -130,6 +130,19 @@ code for the various endpoints as well as the models. The code is placed in the
 tracked and needs to be commited.
 
 
+### Path aliases
+
+The codebase is configured to use path aliases, to more easily arrange imports and to
+avoid excessive levels of relative directories in imports. The code is structured in a
+handful of main subdirectories, like components, routes and utils. There are path aliases
+configured for these subdiretories, which are named prefixed with `#` (ie.
+`#components`). These path aliases are defined in the
+[tsconfig.app.json](tsconfig.app.json) file, and should rarely need to be updated or
+added to. Editors like Visual Studio Code should be able to deal naturally with these
+path aliases. Note that the Vite configuration is set up with a plugin for handling these
+aliases, and that a change in the alias definition list requires a restart of Vite.
+
+
 ### Formatting and linting
 
 There are two tools configured to do formatting and linting of the TypeScript code:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -49,6 +49,7 @@
     "globals": "^15.15.0",
     "typescript": "~5.7.3",
     "typescript-eslint": "^8.32.1",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       vite:
         specifier: ^6.3.5
         version: 6.3.5(jiti@2.4.2)(tsx@4.19.4)
+      vite-tsconfig-paths:
+        specifier: ^5.1.4
+        version: 5.1.4(typescript@5.7.3)(vite@6.3.5(jiti@2.4.2)(tsx@4.19.4))
 
 packages:
 
@@ -1997,6 +2000,9 @@ packages:
     resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
     engines: {node: '>=18'}
 
+  globrex@0.1.2:
+    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
+
   goober@2.1.16:
     resolution: {integrity: sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==}
     peerDependencies:
@@ -2585,6 +2591,16 @@ packages:
   ts-pattern@5.7.0:
     resolution: {integrity: sha512-0/FvIG4g3kNkYgbNwBBW5pZBkfpeYQnH+2AA3xmjkCAit/DSDPKmgwC3fKof4oYUq6gupClVOJlFl+939VRBMg==}
 
+  tsconfck@3.1.6:
+    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
@@ -2649,6 +2665,14 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vite-tsconfig-paths@5.1.4:
+    resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
+    peerDependencies:
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
 
   vite@6.3.5:
     resolution: {integrity: sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==}
@@ -5166,6 +5190,8 @@ snapshots:
 
   globals@15.15.0: {}
 
+  globrex@0.1.2: {}
+
   goober@2.1.16(csstype@3.1.3):
     dependencies:
       csstype: 3.1.3
@@ -5771,6 +5797,10 @@ snapshots:
 
   ts-pattern@5.7.0: {}
 
+  tsconfck@3.1.6(typescript@5.7.3):
+    optionalDependencies:
+      typescript: 5.7.3
+
   tslib@2.6.2: {}
 
   tslib@2.8.1: {}
@@ -5832,6 +5862,17 @@ snapshots:
       react: 19.1.0
 
   vary@1.1.2: {}
+
+  vite-tsconfig-paths@5.1.4(typescript@5.7.3)(vite@6.3.5(jiti@2.4.2)(tsx@4.19.4)):
+    dependencies:
+      debug: 4.4.1
+      globrex: 0.1.2
+      tsconfck: 3.1.6(typescript@5.7.3)
+    optionalDependencies:
+      vite: 6.3.5(jiti@2.4.2)(tsx@4.19.4)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   vite@6.3.5(jiti@2.4.2)(tsx@4.19.4):
     dependencies:

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,8 +1,8 @@
 import { Button, TopBar, Typography } from "@equinor/eds-core-react";
 import { Link } from "@tanstack/react-router";
 
-import fmuLogo from "../assets/fmu_logo.png";
-import { useProject } from "../services/project";
+import fmuLogo from "#assets/fmu_logo.png";
+import { useProject } from "#services/project";
 import { FmuLogo, HeaderContainer, ProjectInfoContainer } from "./Header.style";
 
 function ProjectInfo() {

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -29,11 +29,7 @@ export function Sidebar() {
           />
         </EdsSideBar.Accordion>
         <EdsSideBar.Accordion label="Project" icon={folder}>
-          <EdsSideBar.AccordionItem
-            label="Overview"
-            as={Link}
-            to="/project/overview"
-          />
+          <EdsSideBar.AccordionItem label="Overview" as={Link} to="/project" />
           {ProjectSubItems.map((item) => (
             <EdsSideBar.AccordionItem
               key={item.to}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -2,7 +2,7 @@ import { SideBar as EdsSideBar } from "@equinor/eds-core-react";
 import { account_circle, dashboard, folder } from "@equinor/eds-icons";
 import { Link } from "@tanstack/react-router";
 
-import { useProject } from "../services/project";
+import { useProject } from "#services/project";
 
 type AccordianSubItem = {
   label: string;

--- a/frontend/src/components/common.tsx
+++ b/frontend/src/components/common.tsx
@@ -1,4 +1,4 @@
-import { PageText } from "../styles/common";
+import { PageText } from "#styles/common";
 
 export function Loading() {
   return <PageText>Loading...</PageText>;

--- a/frontend/src/components/form.tsx
+++ b/frontend/src/components/form.tsx
@@ -18,8 +18,8 @@ import {
 import { toast } from "react-toastify";
 import z from "zod/v4";
 
-import { fieldContext, formContext, useFieldContext } from "../utils/form";
-import { handleValidator, ValidatorProps } from "../utils/validator";
+import { fieldContext, formContext, useFieldContext } from "#utils/form";
+import { handleValidator, ValidatorProps } from "#utils/validator";
 import {
   EditableTextFieldFormContainer,
   SearchFieldFormContainer,

--- a/frontend/src/components/project/masterdata/field.tsx
+++ b/frontend/src/components/project/masterdata/field.tsx
@@ -6,14 +6,10 @@ import {
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 
-import { SmdaFieldSearchResult, SmdaFieldUuid } from "../../../client";
-import { smdaPostFieldOptions } from "../../../client/@tanstack/react-query.gen";
-import {
-  PageHeader,
-  PageSectionSpacer,
-  PageText,
-} from "../../../styles/common";
-import { SearchFieldForm } from "../../form";
+import { SmdaFieldSearchResult, SmdaFieldUuid } from "#client";
+import { smdaPostFieldOptions } from "#client/@tanstack/react-query.gen";
+import { SearchFieldForm } from "#components/form";
+import { PageHeader, PageSectionSpacer, PageText } from "#styles/common";
 import { SearchFormContainer, SearchResultsContainer } from "./field.style";
 
 function FieldResults({ data }: { data?: SmdaFieldSearchResult }) {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -25,22 +25,22 @@ import {
 import ReactDOM from "react-dom/client";
 import { toast } from "react-toastify";
 
-import { Message, Options, SessionCreateSessionData } from "./client";
+import { Message, Options, SessionCreateSessionData } from "#client";
 import {
   sessionCreateSessionMutation,
   sessionPatchAccessTokenMutation,
   smdaGetHealthQueryKey,
-} from "./client/@tanstack/react-query.gen";
-import { client } from "./client/client.gen";
-import { msalConfig } from "./config";
-import { routeTree } from "./routeTree.gen";
+} from "#client/@tanstack/react-query.gen";
+import { client } from "#client/client.gen";
+import { msalConfig } from "#config";
 import {
   isApiTokenNonEmpty,
   queryAndMutationRetry,
   responseInterceptorFulfilled,
   responseInterceptorRejected,
   TokenStatus,
-} from "./utils/authentication";
+} from "#utils/authentication";
+import { routeTree } from "./routeTree.gen";
 
 export interface RouterContext {
   queryClient: QueryClient;

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -15,17 +15,17 @@ import { useEffect } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { ToastContainer } from "react-toastify";
 
-import { userGetUserOptions } from "../client/@tanstack/react-query.gen";
-import { Header } from "../components/Header";
-import { Sidebar } from "../components/Sidebar";
-import { RouterContext } from "../main";
-import { PageHeader, PageText } from "../styles/common";
-import GlobalStyle from "../styles/global";
+import { userGetUserOptions } from "#client/@tanstack/react-query.gen";
+import { Header } from "#components/Header";
+import { Sidebar } from "#components/Sidebar";
+import { RouterContext } from "#main";
+import { PageHeader, PageText } from "#styles/common";
+import GlobalStyle from "#styles/global";
 import {
   getApiToken,
   isApiTokenNonEmpty,
   queryAndMutationRetry,
-} from "../utils/authentication";
+} from "#utils/authentication";
 import { AppContainer } from "./index.style";
 
 export const Route = createRootRouteWithContext<RouterContext>()({

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 
-import { PageHeader, PageText } from "../styles/common";
+import { PageHeader, PageText } from "#styles/common";
 
 export const Route = createFileRoute("/")({
   component: RouteComponent,

--- a/frontend/src/routes/project/index.tsx
+++ b/frontend/src/routes/project/index.tsx
@@ -1,11 +1,11 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { Suspense } from "react";
 
-import { FmuProject } from "../../client";
-import { Loading } from "../../components/common";
-import { useProject } from "../../services/project";
-import { PageCode, PageHeader, PageText } from "../../styles/common";
-import { displayDateTime } from "../../utils/datetime";
+import { FmuProject } from "#client";
+import { Loading } from "#components/common";
+import { useProject } from "#services/project";
+import { PageCode, PageHeader, PageText } from "#styles/common";
+import { displayDateTime } from "#utils/datetime";
 import { ProjectName } from "./index.style";
 
 export const Route = createFileRoute("/project/")({

--- a/frontend/src/routes/project/masterdata.tsx
+++ b/frontend/src/routes/project/masterdata.tsx
@@ -14,19 +14,19 @@ import { AxiosError } from "axios";
 import { Suspense, useEffect } from "react";
 import { toast } from "react-toastify";
 
-import { Message, Options, SessionPatchAccessTokenData } from "../../client";
+import { Message, Options, SessionPatchAccessTokenData } from "#client";
 import {
   sessionPatchAccessTokenMutation,
   smdaGetHealthQueryKey,
   userGetUserOptions,
-} from "../../client/@tanstack/react-query.gen";
-import { Loading } from "../../components/common";
-import { Field } from "../../components/project/masterdata/field";
-import { ssoScopes } from "../../config";
-import { useProject } from "../../services/project";
-import { useSmdaHealthCheck } from "../../services/smda";
-import { PageCode, PageHeader, PageText } from "../../styles/common";
-import { queryAndMutationRetry } from "../../utils/authentication";
+} from "#client/@tanstack/react-query.gen";
+import { Loading } from "#components/common";
+import { Field } from "#components/project/masterdata/field";
+import { ssoScopes } from "#config";
+import { useProject } from "#services/project";
+import { useSmdaHealthCheck } from "#services/smda";
+import { PageCode, PageHeader, PageText } from "#styles/common";
+import { queryAndMutationRetry } from "#utils/authentication";
 
 export const Route = createFileRoute("/project/masterdata")({
   component: RouteComponent,

--- a/frontend/src/routes/user/keys.tsx
+++ b/frontend/src/routes/user/keys.tsx
@@ -7,22 +7,22 @@ import {
 import { createFileRoute } from "@tanstack/react-router";
 import { Suspense } from "react";
 
-import { UserApiKeys } from "../../client";
+import { UserApiKeys } from "#client";
 import {
   smdaGetHealthQueryKey,
   userGetUserOptions,
   userGetUserQueryKey,
   userPatchApiKeyMutation,
-} from "../../client/@tanstack/react-query.gen";
-import { Loading } from "../../components/common";
+} from "#client/@tanstack/react-query.gen";
+import { Loading } from "#components/common";
 import {
   CommonTextFieldProps,
   EditableTextFieldForm,
   MutationCallbackProps,
   StringObject,
-} from "../../components/form";
-import { PageHeader, PageSectionSpacer, PageText } from "../../styles/common";
-import { queryAndMutationRetry } from "../../utils/authentication";
+} from "#components/form";
+import { PageHeader, PageSectionSpacer, PageText } from "#styles/common";
+import { queryAndMutationRetry } from "#utils/authentication";
 import { KeysFormContainer } from "./keys.style";
 
 export const Route = createFileRoute("/user/keys")({

--- a/frontend/src/services/project.ts
+++ b/frontend/src/services/project.ts
@@ -1,12 +1,13 @@
 import { queryOptions, useSuspenseQuery } from "@tanstack/react-query";
 import { isAxiosError } from "axios";
+
 import {
   FmuProject,
   Options,
   ProjectGetProjectData,
   projectGetProject,
-} from "../client";
-import { projectGetProjectQueryKey } from "../client/@tanstack/react-query.gen";
+} from "#client";
+import { projectGetProjectQueryKey } from "#client/@tanstack/react-query.gen";
 
 type GetProject = {
   status: boolean;

--- a/frontend/src/services/smda.ts
+++ b/frontend/src/services/smda.ts
@@ -1,8 +1,8 @@
 import { queryOptions, useSuspenseQuery } from "@tanstack/react-query";
 import { isAxiosError } from "axios";
 
-import { Options, SmdaGetHealthData, smdaGetHealth } from "../client";
-import { smdaGetHealthQueryKey } from "../client/@tanstack/react-query.gen";
+import { Options, SmdaGetHealthData, smdaGetHealth } from "#client";
+import { smdaGetHealthQueryKey } from "#client/@tanstack/react-query.gen";
 
 type HealthCheck = {
   status: boolean;

--- a/frontend/src/utils/authentication.ts
+++ b/frontend/src/utils/authentication.ts
@@ -2,7 +2,7 @@ import { UseMutateAsyncFunction } from "@tanstack/react-query";
 import { AxiosError, AxiosResponse, isAxiosError } from "axios";
 import { Dispatch, SetStateAction } from "react";
 
-import { Message, Options, SessionCreateSessionData } from "../client";
+import { Message, Options, SessionCreateSessionData } from "#client";
 import { getStorageItem, removeStorageItem, setStorageItem } from "./storage";
 
 const FRAGMENTTOKEN_PREFIX = "#token=";

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -15,6 +15,18 @@
     "noEmit": true,
     "jsx": "react-jsx",
 
+    /* Path aliases */
+    "paths": {
+      "#assets": ["./src/assets"],
+      "#client": ["./src/client"],
+      "#client/*": ["./src/client/*"],
+      "#components/*": ["./src/components/*"],
+      "#config": ["./src/config.ts"],
+      "#services/*": ["./src/services/*"],
+      "#styles/*": ["./src/styles/*"],
+      "#utils/*": ["./src/utils/*"],
+    },
+
     /* Linting */
     "strict": true,
     "noUnusedLocals": true,

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -17,11 +17,12 @@
 
     /* Path aliases */
     "paths": {
-      "#assets": ["./src/assets"],
+      "#assets/*": ["./src/assets/*"],
       "#client": ["./src/client"],
       "#client/*": ["./src/client/*"],
       "#components/*": ["./src/components/*"],
       "#config": ["./src/config.ts"],
+      "#main": ["./src/main.tsx"],
       "#services/*": ["./src/services/*"],
       "#styles/*": ["./src/styles/*"],
       "#utils/*": ["./src/utils/*"],

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,10 +1,12 @@
 import { TanStackRouterVite } from "@tanstack/router-plugin/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
+import tsconfigPaths from "vite-tsconfig-paths";
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
+    tsconfigPaths(),
     TanStackRouterVite({
       target: "react",
       routeFileIgnorePattern: ".style.ts",


### PR DESCRIPTION
Resolves #51 

Defines path aliases for imports, which simplifies the import statements. The prefix used for aliases is `#`, and the aliases are defined in `tsconfig.app.json`. In addition, the Biome configuration is updated with a custom import sort rule, putting third-party libraries first, followed by a blank line and then aliases and the regular path imports. Also fixes an incorrect link in the main menu to the project page.

## Checklist

- [X] Tests added - not relevant
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
