### PR TITLE
Avoid parallel session creations

### DIFF
--- a/frontend/src/routes/project/masterdata.tsx
+++ b/frontend/src/routes/project/masterdata.tsx
@@ -1,20 +1,10 @@
-import {
-  InteractionRequiredAuthError,
-  IPublicClientApplication,
-} from "@azure/msal-browser";
+import { InteractionRequiredAuthError } from "@azure/msal-browser";
 import { useIsAuthenticated, useMsal } from "@azure/msal-react";
 import { Button, DotProgress } from "@equinor/eds-core-react";
-import {
-  UseMutateFunction,
-  useMutation,
-  useSuspenseQuery,
-} from "@tanstack/react-query";
+import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { AxiosError } from "axios";
 import { Suspense, useEffect } from "react";
-import { toast } from "react-toastify";
 
-import { Message, Options, SessionPatchAccessTokenData } from "#client";
 import {
   sessionPatchAccessTokenMutation,
   smdaGetHealthQueryKey,
@@ -26,7 +16,11 @@ import { ssoScopes } from "#config";
 import { useProject } from "#services/project";
 import { useSmdaHealthCheck } from "#services/smda";
 import { PageCode, PageHeader, PageText } from "#styles/common";
-import { queryAndMutationRetry } from "#utils/authentication";
+import {
+  handleAddSsoAccessToken,
+  handleSsoLogin,
+  queryAndMutationRetry,
+} from "#utils/authentication";
 
 export const Route = createFileRoute("/project/masterdata")({
   component: RouteComponent,
@@ -55,26 +49,6 @@ function SubscriptionKeyPresence() {
       )}
     </PageText>
   );
-}
-
-function handleLogin(msalInstance: IPublicClientApplication) {
-  try {
-    void msalInstance.loginRedirect({ scopes: ssoScopes });
-  } catch (error) {
-    console.error("Error when logging in to SSO: ", error);
-    toast.error(String(error));
-  }
-}
-
-function handleAddAccessToken(
-  accessToken: string,
-  patchAccessTokenMutate: UseMutateFunction<
-    Message,
-    AxiosError,
-    Options<SessionPatchAccessTokenData>
-  >,
-) {
-  patchAccessTokenMutate({ body: { id: "smda_api", key: accessToken } });
 }
 
 function AccessTokenPresence() {
@@ -115,7 +89,7 @@ function AccessTokenPresence() {
             is present. Try adding it to the session:{" "}
             <Button
               onClick={() => {
-                handleAddAccessToken(accessToken, patchAccessTokenMutate);
+                handleAddSsoAccessToken(patchAccessTokenMutate, accessToken);
               }}
             >
               {isPending ? <DotProgress /> : "Add to session"}
@@ -127,7 +101,7 @@ function AccessTokenPresence() {
             in:{" "}
             <Button
               onClick={() => {
-                handleLogin(msalInstance);
+                handleSsoLogin(msalInstance);
               }}
             >
               Log in


### PR DESCRIPTION
Resolves #54

Fixes the bug where multiple API requests returning a status of unauthorized access (ie. missing a session to the API) results in multiple session creation requests. Also ensures that if an SSO access token is present it will be added to the newly created session. Also ensures that an unauthorized access status from getting the project data results in a retry, the same as for other API requests.

## Checklist

- [ ] Tests added - not relevant
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
