### PR TITLE
ENH: Add option to prevent default error handling

### DIFF
--- a/frontend/src/utils/query.ts
+++ b/frontend/src/utils/query.ts
@@ -1,0 +1,15 @@
+import { isAxiosError } from "axios";
+import { toast } from "react-toastify";
+
+export const defaultErrorHandling = (error: Error, errorPrefix: string) => {
+  const message =
+    `${errorPrefix}: ` +
+    (isAxiosError(error) &&
+    error.response?.data &&
+    "detail" in error.response.data
+      ? // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        String(error.response.data.detail)
+      : error.message);
+  console.error(message);
+  toast.error(message);
+};


### PR DESCRIPTION
Resolves #63 

PR to add a new property in `meta` that can be used to prevent the default error handling.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
