### PR TITLE
Fix SMDA subscription key check

### DIFF
--- a/frontend/src/routes/project/masterdata.tsx
+++ b/frontend/src/routes/project/masterdata.tsx
@@ -27,6 +27,7 @@ function SubscriptionKeyPresence() {
 
   const hasSubscriptionKey =
     "smda_subscription" in userData.user_api_keys &&
+    typeof userData.user_api_keys.smda_subscription === "string" &&
     userData.user_api_keys.smda_subscription !== "";
 
   return (


### PR DESCRIPTION
Resolves #73 

Correctly handles a `null` value of the SMDA subscription key.

## Checklist

- [ ] Tests added - not relevant
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
