### PR TITLE
MAINT: Switch to using useQueryClient where possible

### DIFF
--- a/frontend/src/routes/project/masterdata.tsx
+++ b/frontend/src/routes/project/masterdata.tsx
@@ -1,7 +1,11 @@
 import { InteractionRequiredAuthError } from "@azure/msal-browser";
 import { useIsAuthenticated, useMsal } from "@azure/msal-react";
 import { Button, DotProgress } from "@equinor/eds-core-react";
-import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { Suspense, useEffect } from "react";
 
@@ -49,7 +53,8 @@ function SubscriptionKeyPresence() {
 }
 
 function AccessTokenPresence() {
-  const { queryClient, accessToken } = Route.useRouteContext();
+  const queryClient = useQueryClient();
+  const { accessToken } = Route.useRouteContext();
   const { instance: msalInstance } = useMsal();
   const isAuthenticated = useIsAuthenticated();
 

--- a/frontend/src/routes/user/keys.tsx
+++ b/frontend/src/routes/user/keys.tsx
@@ -1,7 +1,7 @@
 import { Typography } from "@equinor/eds-core-react";
 import {
-  QueryClient,
   useMutation,
+  useQueryClient,
   useSuspenseQuery,
 } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
@@ -30,17 +30,16 @@ export const Route = createFileRoute("/user/keys")({
 
 type KeysTextFieldFormProps = Omit<CommonTextFieldProps, "name" | "value"> & {
   apiKey: keyof UserApiKeys;
-  queryClient: QueryClient;
 };
 
 function KeysTextFieldForm({
   apiKey,
   label,
-  queryClient,
   placeholder,
   length,
   minLength,
 }: KeysTextFieldFormProps) {
+  const queryClient = useQueryClient();
   const { data } = useSuspenseQuery(userGetUserOptions());
   const { mutate, isPending } = useMutation({
     ...userPatchApiKeyMutation(),
@@ -90,8 +89,6 @@ function KeysTextFieldForm({
 }
 
 function Content() {
-  const { queryClient } = Route.useRouteContext();
-
   return (
     <>
       <PageText $variant="ingress">
@@ -147,7 +144,6 @@ function Content() {
           label="SMDA subscription primary key"
           placeholder="(not set)"
           length={32}
-          queryClient={queryClient}
         />
       </KeysFormContainer>
     </>


### PR DESCRIPTION
Resolves #57 

PR to switch to using the `useQueryClient` hook where possible instead of fetching it from the router context.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
