### PR TITLE
ENH: Add more info to the header

### DIFF
--- a/frontend/src/components/Header.style.ts
+++ b/frontend/src/components/Header.style.ts
@@ -9,13 +9,17 @@ export const FmuLogo = styled.img`
 `;
 
 export const ProjectInfoContainer = styled.div`
-  padding: 0.5em;
+  height: ${tokens.spacings.comfortable.x_large};
+  padding: 0.4em ${tokens.spacings.comfortable.medium};
   border: solid 1px ${tokens.colors.ui.background__medium.hex};
-  background: ${tokens.colors.ui.background__light.hex};
-  color: ${tokens.colors.text.static_icons__secondary.hex};
   border-radius: ${tokens.shape.corners.borderRadius};
+  background: ${tokens.colors.ui.background__light.hex};
 
-  span {
-    font-weight: bold;
-  }
+  display: flex;
+  align-items: center;
+  gap: ${tokens.spacings.comfortable.large};
+`;
+
+export const ProjectInfoItemContainer = styled.div`
+  text-align: left;
 `;

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -2,36 +2,78 @@ import { Button, Tooltip, TopBar, Typography } from "@equinor/eds-core-react";
 import { Link } from "@tanstack/react-router";
 
 import fmuLogo from "#assets/fmu_logo.png";
+import { LockInfo } from "#client/types.gen";
 import { LockIcon } from "#components/LockStatus";
 import { useProject } from "#services/project";
-import { FmuLogo, HeaderContainer, ProjectInfoContainer } from "./Header.style";
+import {
+  FmuLogo,
+  HeaderContainer,
+  ProjectInfoContainer,
+  ProjectInfoItemContainer,
+} from "./Header.style";
+
+function LockStatusIcon({
+  isReadOnly,
+  lockInfo,
+}: {
+  isReadOnly: boolean;
+  lockInfo: LockInfo | null | undefined;
+}) {
+  return (
+    <Tooltip
+      title={
+        isReadOnly
+          ? "Project is read-only" +
+            (lockInfo
+              ? ` and locked by ${lockInfo.user}@${lockInfo.hostname}`
+              : "")
+          : "Project is editable"
+      }
+    >
+      <span>
+        <LockIcon isReadOnly={isReadOnly} />
+      </span>
+    </Tooltip>
+  );
+}
+
+function ProjectInfoItem({ label, value }: { label: string; value?: string }) {
+  return (
+    <ProjectInfoItemContainer>
+      <Typography variant="caption">{label}</Typography>
+      <Typography bold color={value ? undefined : "warning"}>
+        {value ?? "not set"}
+      </Typography>
+    </ProjectInfoItemContainer>
+  );
+}
 
 function ProjectInfo() {
   const project = useProject();
-  const lockInfo = project.lockStatus?.lock_info;
 
   return (
     <ProjectInfoContainer>
       {project.status && project.data ? (
         <>
-          <Tooltip
-            title={
-              project.data.is_read_only
-                ? "Project is read-only" +
-                  (lockInfo
-                    ? ` and locked by ${lockInfo.user}@${lockInfo.hostname}`
-                    : "")
-                : "Project is editable"
-            }
-          >
-            <span>
-              <LockIcon isReadOnly={project.data.is_read_only ?? true} />
-            </span>
-          </Tooltip>
-          <span> {project.data.project_dir_name}</span>
+          <LockStatusIcon
+            isReadOnly={project.data.is_read_only ?? true}
+            lockInfo={project.lockStatus?.lock_info}
+          />
+          <ProjectInfoItem
+            label="Asset"
+            value={project.data.config.access?.asset.name}
+          />
+          <ProjectInfoItem
+            label="Model"
+            value={project.data.config.model?.name}
+          />
+          <ProjectInfoItem
+            label="Revision"
+            value={project.data.config.model?.revision}
+          />
         </>
       ) : (
-        "(not set)"
+        "No project selected"
       )}
     </ProjectInfoContainer>
   );


### PR DESCRIPTION
Resolves #104 

PR to add more information about the opened project in the top bar header.
Currently asset name and model name and revision are added. 

We could add the path to the opened project as well since we don't yet have a mechanism in place to know if this is a user copy or not - but that path is often long and it just doesn't look nice in the header. I would rather have an icon of some sort to indicate if it is a user copy or not.

<img width="1481" height="660" alt="image" src="https://github.com/user-attachments/assets/356ceb4c-8b89-4e7a-ae2f-dc592f561037" />


## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
