### PR TITLE
BUG: Only enable lockStatus query when active project

### DIFF
--- a/frontend/src/components/LockStatus.tsx
+++ b/frontend/src/components/LockStatus.tsx
@@ -135,7 +135,8 @@ export function LockStatusBanner({
   const queryClient = useQueryClient();
 
   useEffect(() => {
-    if (!lockStatus?.lock_info) {
+    if (lockStatus && !lockStatus.lock_info) {
+      console.log(lockStatus);
       if (isReadOnly) {
         toast.info(
           "Project can be opened for editing from the project overview page.",
@@ -147,7 +148,7 @@ export function LockStatusBanner({
         });
       }
     }
-  }, [lockStatus?.lock_info, isReadOnly, queryClient]);
+  }, [lockStatus, isReadOnly, queryClient]);
 
   return (
     <Banner>

--- a/frontend/src/services/project.ts
+++ b/frontend/src/services/project.ts
@@ -1,4 +1,8 @@
-import { queryOptions, useSuspenseQuery } from "@tanstack/react-query";
+import {
+  queryOptions,
+  useQuery,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
 import { isAxiosError } from "axios";
 
 import {
@@ -54,9 +58,10 @@ export function useProject(options?: Options<ProjectGetProjectData>) {
     }),
   );
 
-  const { data: lockStatus } = useSuspenseQuery({
+  const { data: lockStatus } = useQuery({
     ...projectGetLockStatusOptions(),
     refetchInterval: projectLockStatusRefetchInterval,
+    enabled: project.status && project.data !== undefined,
   });
 
   return {


### PR DESCRIPTION
Resolves #110 

PR to fix a bug that came after #91, where the fmu settings application did not open if outside a project due to the lock_status query failing. This is fixed here by enabling this query only when project data is present.

Note in the future we will aim to get lock status information in the `GET /project` endpoint instead to keep the `is_read_only` status and the lock information always in sync.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
