### PR TITLE
ENH: Add Feedback button to header

### DIFF
--- a/frontend/src/components/Header.style.ts
+++ b/frontend/src/components/Header.style.ts
@@ -1,3 +1,4 @@
+import { Button } from "@equinor/eds-core-react";
 import { tokens } from "@equinor/eds-tokens";
 import styled from "styled-components";
 
@@ -22,4 +23,12 @@ export const ProjectInfoContainer = styled.div`
 
 export const ProjectInfoItemContainer = styled.div`
   text-align: left;
+`;
+
+export const HeaderActionButton = styled(Button).attrs({
+  variant: "ghost",
+})`
+  &:hover {
+    background: inherit;
+  }
 `;

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,12 +1,23 @@
-import { Button, Tooltip, TopBar, Typography } from "@equinor/eds-core-react";
+import {
+  Button,
+  Dialog,
+  Icon,
+  Tooltip,
+  TopBar,
+  Typography,
+} from "@equinor/eds-core-react";
+import { comment } from "@equinor/eds-icons";
 import { Link } from "@tanstack/react-router";
+import { useState } from "react";
 
 import fmuLogo from "#assets/fmu_logo.png";
 import { LockInfo } from "#client/types.gen";
 import { LockIcon } from "#components/LockStatus";
 import { useProject } from "#services/project";
+import { EditDialog, PageText } from "#styles/common";
 import {
   FmuLogo,
+  HeaderActionButton,
   HeaderContainer,
   ProjectInfoContainer,
   ProjectInfoItemContainer,
@@ -79,6 +90,72 @@ function ProjectInfo() {
   );
 }
 
+function FeedbackDialog() {
+  const [isOpen, setIsOpen] = useState(false);
+  const closeDialog = () => {
+    setIsOpen(false);
+  };
+  const openDialog = () => {
+    setIsOpen(true);
+  };
+
+  return (
+    <>
+      <HeaderActionButton onClick={openDialog}>
+        Feedback <Icon data={comment} size={18} />
+      </HeaderActionButton>
+
+      <EditDialog
+        isDismissable={true}
+        open={isOpen}
+        onClose={closeDialog}
+        $maxWidth="32em"
+      >
+        <Dialog.Header>Let us know what you think</Dialog.Header>
+
+        <Dialog.Content>
+          <PageText>
+            We are actively developing FMU Settings and always welcome your
+            feedback! Your insights help us prioritize our efforts.
+          </PageText>
+
+          <PageText>
+            We prefer open feedback on{" "}
+            <Typography
+              link
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://app.slack.com/client/E086B9P9JM9/C09MFKN4NC9"
+            >
+              Slack
+            </Typography>{" "}
+            or{" "}
+            <Typography
+              link
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://engage.cloud.microsoft/main/org/statoil.com/groups/eyJfdHlwZSI6Ikdyb3VwIiwiaWQiOiI3OTMyMjAxIn0"
+            >
+              Viva Engage
+            </Typography>
+            . However, you can also contact the{" "}
+            <Typography link href="mailto:fg_fmu-atlas@equinor.com">
+              Atlas
+            </Typography>{" "}
+            team directly.
+          </PageText>
+
+          <PageText>Thanks! 🙏</PageText>
+        </Dialog.Content>
+
+        <Dialog.Actions>
+          <Button onClick={closeDialog}>Close</Button>
+        </Dialog.Actions>
+      </EditDialog>
+    </>
+  );
+}
+
 export function Header() {
   return (
     <HeaderContainer>
@@ -95,6 +172,7 @@ export function Header() {
           <Typography variant="h1_bold">FMU Settings</Typography>
         </TopBar.Header>
         <TopBar.Actions>
+          <FeedbackDialog />
           <ProjectInfo />
         </TopBar.Actions>
       </TopBar>

--- a/frontend/src/styles/common.ts
+++ b/frontend/src/styles/common.ts
@@ -68,9 +68,15 @@ export const InfoChip = styled(Chip)`
   }
 `;
 
-export const EditDialog = styled(Dialog).attrs<{ $minWidth?: string }>(
-  (props) => ({ style: { minWidth: props.$minWidth ?? "10em" } }),
-)`
+export const EditDialog = styled(Dialog).attrs<{
+  $minWidth?: string;
+  $maxWidth?: string;
+}>((props) => ({
+  style: {
+    minWidth: props.$minWidth ?? "10em",
+    maxWidth: props.$maxWidth ?? "20em",
+  },
+}))`
   width: 100%;
   
   #eds-dialog-customcontent {


### PR DESCRIPTION
Resolves #109 

Add Feedback button to top bar header. 
This is kept as equal to the feedback functionality in the Sumo frontend as possible.

<img width="1257" height="70" alt="2025-10-30_14-46-20" src="https://github.com/user-attachments/assets/d293b703-e2da-4c84-ba3f-a348149cb727" />

<img width="60%" height="60%" alt="2025-10-30_14-48-39" src="https://github.com/user-attachments/assets/bf6c31da-64dc-4659-9437-32991555a129" />


## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
