### PR TITLE
ENH: Highlight active page in the sidebar

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { SideBar as EdsSideBar } from "@equinor/eds-core-react";
 import { account_circle, dashboard, folder } from "@equinor/eds-icons";
-import { Link } from "@tanstack/react-router";
+import { Link, useLocation } from "@tanstack/react-router";
 
 import { useProject } from "#services/project";
 
@@ -11,6 +11,7 @@ type AccordianSubItem = {
 
 export function Sidebar() {
   const project = useProject();
+  const location = useLocation();
 
   const ProjectSubItems: AccordianSubItem[] = [];
   if (project.status) {
@@ -20,15 +21,27 @@ export function Sidebar() {
   return (
     <EdsSideBar open>
       <EdsSideBar.Content>
-        <EdsSideBar.Link label="Home" icon={dashboard} as={Link} to="/" />
+        <EdsSideBar.Link
+          label="Home"
+          icon={dashboard}
+          as={Link}
+          to="/"
+          active={location.pathname === "/"}
+        />
         <EdsSideBar.Accordion label="Project" icon={folder}>
-          <EdsSideBar.AccordionItem label="Overview" as={Link} to="/project" />
+          <EdsSideBar.AccordionItem
+            label="Overview"
+            as={Link}
+            to="/project"
+            active={location.pathname === "/project"}
+          />
           {ProjectSubItems.map((item) => (
             <EdsSideBar.AccordionItem
               key={item.to}
               label={item.label}
               as={Link}
               to={item.to}
+              active={location.pathname === item.to}
             />
           ))}
         </EdsSideBar.Accordion>
@@ -37,6 +50,7 @@ export function Sidebar() {
             label="API keys"
             as={Link}
             to="/user/keys"
+            active={location.pathname === "/user/keys"}
           />
         </EdsSideBar.Accordion>
       </EdsSideBar.Content>


### PR DESCRIPTION
Resolves #114 

PR to add highlighting of the active page in the sidebar
<img width="90%" height="90%" alt="image" src="https://github.com/user-attachments/assets/72daff1b-3d50-4a6d-8e54-014e785be477" />


## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
