### PR TITLE
ENH: Fetch lock status every minute

### DIFF
--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -13,4 +13,4 @@ export const ssoScopes = [
   "691a29c5-8199-4e87-80a2-16bd71e831cd/user_impersonation", // SMDA
 ];
 
-export const projectLockStatusRefetchInterval = 300_000; // 5 minutes
+export const projectLockStatusRefetchInterval = 60_000; // 1 minute


### PR DESCRIPTION
For the demo fetch the lock status every minute instead

Will add an issue to revisit the fetch interval

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
