### PR TITLE
MAINT: Move resources to separate file

### DIFF
--- a/frontend/src/components/home/Resources.style.ts
+++ b/frontend/src/components/home/Resources.style.ts
@@ -1,0 +1,21 @@
+import { Card } from "@equinor/eds-core-react";
+import { tokens } from "@equinor/eds-tokens";
+import styled from "styled-components";
+
+export const ResourcesContainer = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  gap: ${tokens.spacings.comfortable.medium};
+`;
+
+export const ResourceCard = styled(Card)`
+  width: 250px; 
+  border: solid 1px ${tokens.colors.ui.background__medium.hex};
+  background: ${tokens.colors.ui.background__light.hex};  
+`;
+
+export const Logo = styled.img`
+  width: 35px;
+  height: auto;
+`;

--- a/frontend/src/components/home/Resources.tsx
+++ b/frontend/src/components/home/Resources.tsx
@@ -1,0 +1,153 @@
+import { Card, Typography } from "@equinor/eds-core-react";
+
+import ertLogo from "#assets/ert.png";
+import fmuLogo from "#assets/fmu_logo.png";
+import sumoLogo from "#assets/sumo.png";
+import webvizLogo from "#assets/webviz.png";
+import { PageHeader, PageText } from "#styles/common";
+import { ResourceCard, ResourcesContainer } from "./Resources.style";
+import { Logo } from "./Resources.style";
+
+export function Resources() {
+  return (
+    <>
+      <PageHeader variant="h3">Resources</PageHeader>
+
+      <ResourcesContainer>
+        <ResourceCard>
+          <Card.Header>
+            <Card.HeaderTitle>
+              <Typography variant="h5">FMU Hub</Typography>
+            </Card.HeaderTitle>
+            <Logo src={fmuLogo} />
+          </Card.Header>
+          <Card.Content>
+            <PageText>
+              FMU Hub - the place for everything related to FMU. Expert or noob,
+              user or developer, skeptic or believer - the site is for you and
+              the rest of the amazing FMU community.
+            </PageText>
+          </Card.Content>
+          <Card.Actions>
+            <Typography
+              link
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://fmu.equinor.com/"
+            >
+              Homepage
+            </Typography>
+          </Card.Actions>
+        </ResourceCard>
+
+        <ResourceCard>
+          <Card.Header>
+            <Card.HeaderTitle>
+              <Typography variant="h5">Sumo</Typography>
+            </Card.HeaderTitle>
+            <Logo src={sumoLogo} />
+          </Card.Header>
+          <Card.Content>
+            <PageText>
+              Sumo is a solution for receiving, storing and serving results
+              produced by numerical predictive models of the subsurface.
+            </PageText>
+          </Card.Content>
+          <Card.Actions>
+            <Typography
+              link
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://fmu-sumo.app.radix.equinor.com/"
+            >
+              Homepage
+            </Typography>
+
+            <Typography
+              link
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://doc-sumo-doc-prod.radix.equinor.com/"
+            >
+              Documentation
+            </Typography>
+          </Card.Actions>
+        </ResourceCard>
+
+        <ResourceCard>
+          <Card.Header>
+            <Card.HeaderTitle>
+              <Typography variant="h5">ERT</Typography>
+            </Card.HeaderTitle>
+            <Logo src={ertLogo} />
+          </Card.Header>
+          <Card.Content>
+            <PageText>
+              ERT - Ensemble based Reservoir Tool - is a tool to run
+              ensemble-based reservoir models.
+            </PageText>
+          </Card.Content>
+          <Card.Actions>
+            <Typography
+              link
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://fmu-docs.equinor.com/docs/ert/index.html"
+            >
+              Documentation
+            </Typography>
+          </Card.Actions>
+        </ResourceCard>
+
+        <ResourceCard>
+          <Card.Header>
+            <Card.HeaderTitle>
+              <Typography variant="h5">Webviz</Typography>
+            </Card.HeaderTitle>
+            <Logo src={webvizLogo} />
+          </Card.Header>
+          <Card.Content>
+            <PageText>
+              Webviz is a visualization tool and facilitate easy access of FMU
+              modelling results.
+            </PageText>
+          </Card.Content>
+          <Card.Actions>
+            <Typography
+              link
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://webviz.fmu.equinor.com"
+            >
+              Documentation
+            </Typography>
+          </Card.Actions>
+        </ResourceCard>
+
+        <ResourceCard>
+          <Card.Header>
+            <Card.HeaderTitle>
+              <Typography variant="h5">fmu-dataio</Typography>
+            </Card.HeaderTitle>
+          </Card.Header>
+          <Card.Content>
+            <PageText>
+              fmu-dataio contains utility functions for data transfer of FMU
+              data with rich metadata, for REP, Sumo, Webviz, etc.
+            </PageText>
+          </Card.Content>
+          <Card.Actions>
+            <Typography
+              link
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://fmu-dataio.readthedocs.io/en/latest/"
+            >
+              Documentation
+            </Typography>
+          </Card.Actions>
+        </ResourceCard>
+      </ResourcesContainer>
+    </>
+  );
+}

--- a/frontend/src/components/project/overview/Model.tsx
+++ b/frontend/src/components/project/overview/Model.tsx
@@ -19,7 +19,6 @@ import { TextField } from "#components/form/field";
 import {
   EditDialog,
   InfoBox,
-  InfoChip,
   PageCode,
   PageHeader,
   PageSectionSpacer,
@@ -158,7 +157,7 @@ function ModelInfo({ modelData }: { modelData: Model }) {
           </tr>
           <tr>
             <th>Revision</th>
-            <td>{<InfoChip>{modelData.revision}</InfoChip>}</td>
+            <td>{modelData.revision}</td>
           </tr>
         </tbody>
       </table>

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,158 +1,11 @@
-import { Card, Typography } from "@equinor/eds-core-react";
 import { createFileRoute } from "@tanstack/react-router";
 
-import ertLogo from "#assets/ert.png";
-import fmuLogo from "#assets/fmu_logo.png";
-import sumoLogo from "#assets/sumo.png";
-import webvizLogo from "#assets/webviz.png";
-import { FmuLogo } from "#components/Header.style";
-import { PageHeader, PageText } from "#styles/common";
-import { CardContainer, StyledContainer } from "./index.style";
-import { ErtLogo, SumoLogo, WebvizLogo } from "./index.style";
+import { Resources } from "#components/home/Resources";
+import { PageHeader, PageSectionSpacer, PageText } from "#styles/common";
 
 export const Route = createFileRoute("/")({
   component: RouteComponent,
 });
-
-function Documentation() {
-  return (
-    <StyledContainer>
-      <CardContainer>
-        <Card.Header>
-          <Card.HeaderTitle>
-            <Typography variant="h5">FMU Hub</Typography>
-          </Card.HeaderTitle>
-          <FmuLogo src={fmuLogo} />
-        </Card.Header>
-        <Card.Content>
-          <PageText>
-            FMU Hub - the place for everything related to FMU. Expert or noob,
-            user or developer, skeptic or believer - the site is for you and the
-            rest of the amazing FMU community.
-          </PageText>
-        </Card.Content>
-        <Card.Actions>
-          <Typography
-            link
-            target="_blank"
-            rel="noopener noreferrer"
-            href="https://fmu.equinor.com/"
-          >
-            Homepage
-          </Typography>
-        </Card.Actions>
-      </CardContainer>
-
-      <CardContainer>
-        <Card.Header>
-          <Card.HeaderTitle>
-            <Typography variant="h5">Sumo</Typography>
-          </Card.HeaderTitle>
-          <SumoLogo src={sumoLogo} />
-        </Card.Header>
-        <Card.Content>
-          <PageText>
-            Sumo is a solution for receiving, storing and serving results
-            produced by numerical predictive models of the subsurface.
-          </PageText>
-        </Card.Content>
-        <Card.Actions>
-          <Typography
-            link
-            target="_blank"
-            rel="noopener noreferrer"
-            href="https://fmu-sumo.app.radix.equinor.com/"
-          >
-            Homepage
-          </Typography>
-
-          <Typography
-            link
-            target="_blank"
-            rel="noopener noreferrer"
-            href="https://doc-sumo-doc-prod.radix.equinor.com/"
-          >
-            Documentation
-          </Typography>
-        </Card.Actions>
-      </CardContainer>
-
-      <CardContainer>
-        <Card.Header>
-          <Card.HeaderTitle>
-            <Typography variant="h5">ERT</Typography>
-          </Card.HeaderTitle>
-          <ErtLogo src={ertLogo} />
-        </Card.Header>
-        <Card.Content>
-          <PageText>
-            ERT - Ensemble based Reservoir Tool - is a tool to run
-            ensemble-based reservoir models.
-          </PageText>
-        </Card.Content>
-        <Card.Actions>
-          <Typography
-            link
-            target="_blank"
-            rel="noopener noreferrer"
-            href="https://fmu-docs.equinor.com/docs/ert/index.html"
-          >
-            Documentation
-          </Typography>
-        </Card.Actions>
-      </CardContainer>
-
-      <CardContainer>
-        <Card.Header>
-          <Card.HeaderTitle>
-            <Typography variant="h5">Webviz</Typography>
-          </Card.HeaderTitle>
-          <WebvizLogo src={webvizLogo} />
-        </Card.Header>
-        <Card.Content>
-          <PageText>
-            Webviz is a visualization tool and facilitate easy access of FMU
-            modelling results.
-          </PageText>
-        </Card.Content>
-        <Card.Actions>
-          <Typography
-            link
-            target="_blank"
-            rel="noopener noreferrer"
-            href="https://webviz.fmu.equinor.com"
-          >
-            Documentation
-          </Typography>
-        </Card.Actions>
-      </CardContainer>
-
-      <CardContainer>
-        <Card.Header>
-          <Card.HeaderTitle>
-            <Typography variant="h5">fmu-dataio</Typography>
-          </Card.HeaderTitle>
-        </Card.Header>
-        <Card.Content>
-          <PageText>
-            fmu-dataio contains utility functions for data transfer of FMU data
-            with rich metadata, for REP, Sumo, Webviz, etc.
-          </PageText>
-        </Card.Content>
-        <Card.Actions>
-          <Typography
-            link
-            target="_blank"
-            rel="noopener noreferrer"
-            href="https://fmu-dataio.readthedocs.io/en/latest/"
-          >
-            Documentation
-          </Typography>
-        </Card.Actions>
-      </CardContainer>
-    </StyledContainer>
-  );
-}
 
 function RouteComponent() {
   return (
@@ -163,7 +16,9 @@ function RouteComponent() {
         This is an application for managing the settings of FMU projects.
       </PageText>
 
-      <Documentation />
+      <PageSectionSpacer />
+
+      <Resources />
     </>
   );
 }


### PR DESCRIPTION
PR to move the documentation cards on the homepage into a separate file. 

Mainly just a move of the existing code, but it also adds a header above the cards. 
<img width="1204" height="898" alt="image" src="https://github.com/user-attachments/assets/845bc61c-1c74-430b-94d7-ed832509766f" />


## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
