### PR TITLE
MAINT: Remove unused code from index.style.ts

### DIFF
--- a/frontend/src/routes/index.style.ts
+++ b/frontend/src/routes/index.style.ts
@@ -1,5 +1,3 @@
-import { Card } from "@equinor/eds-core-react";
-import { tokens } from "@equinor/eds-tokens";
 import styled from "styled-components";
 
 export const AppContainer = styled.div`
@@ -26,32 +24,4 @@ export const AppContainer = styled.div`
     max-width: 55em;
     padding: 24px;
   }
-`;
-
-export const StyledContainer = styled.div`
-  display: flex;
-  justify-content: flex-start;
-  flex-wrap: wrap;
-  gap: ${tokens.spacings.comfortable.medium};
-`;
-
-export const CardContainer = styled(Card)`
-  width: 250px; 
-  border: solid 1px ${tokens.colors.ui.background__medium.hex};
-  background: ${tokens.colors.ui.background__light.hex};  
-`;
-
-export const SumoLogo = styled.img`
-  width: 35px;
-  height: auto;
-`;
-
-export const WebvizLogo = styled.img`
-  width: 35px;
-  height: auto;
-`;
-
-export const ErtLogo = styled.img`
-  width: 35px;
-  height: auto;
 `;


### PR DESCRIPTION
The recently merged PR #130 moved styling of the resources to `components/home/Resources.style.ts`.
I realized after merging that the PR did not contain removal of the old styles for the resource cards in `index.style.ts`, hence this is done here.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
