### PR TITLE
BUG: Remove sorted coordinate system

### DIFF
--- a/frontend/src/components/project/masterdata/Edit.tsx
+++ b/frontend/src/components/project/masterdata/Edit.tsx
@@ -104,9 +104,7 @@ function createReferenceData(
     // The list of coordinate systems is the same for all SMDA fields
     coordinateSystems:
       fieldCount > 0
-        ? Object.values(smdaMasterdataGrouped)[0].coordinate_systems.sort(
-            (a, b) => stringCompare(a.identifier, b.identifier),
-          )
+        ? Object.values(smdaMasterdataGrouped)[0].coordinate_systems
         : [],
     stratigraphicColumns: Object.values(smdaMasterdataGrouped)
       .reduce<Array<StratigraphicColumn>>((acc, masterdata) => {


### PR DESCRIPTION
Resolves #135 

Coordinate system from API is now returning field-related coordinate system on top and then random order after that. However, if multiple field are searched, we don't know which coordinate system belong to which field, just that the relevant one are on top. Is this something that we want to know?

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
