### PR TITLE
ENH: Display validation error messages for Model and Access

### DIFF
--- a/frontend/src/components/project/overview/Access.tsx
+++ b/frontend/src/components/project/overview/Access.tsx
@@ -33,6 +33,10 @@ import {
   PageSectionSpacer,
   PageText,
 } from "#styles/common";
+import {
+  HTTP_STATUS_UNPROCESSABLE_CONTENT,
+  httpValidationErrorToString,
+} from "#utils/api";
 import { fieldContext, formContext } from "#utils/form";
 import { requiredStringValidator } from "#utils/validator";
 
@@ -69,6 +73,17 @@ function AccessEditorForm({
       void queryClient.invalidateQueries({
         queryKey: projectGetProjectQueryKey(),
       });
+    },
+    onError: (error) => {
+      if (error.response?.status === HTTP_STATUS_UNPROCESSABLE_CONTENT) {
+        const message = httpValidationErrorToString(error);
+        console.error(message);
+        toast.error(message);
+      }
+    },
+    meta: {
+      errorPrefix: "Error saving access information",
+      preventDefaultErrorHandling: [HTTP_STATUS_UNPROCESSABLE_CONTENT],
     },
   });
 

--- a/frontend/src/components/project/overview/Model.tsx
+++ b/frontend/src/components/project/overview/Model.tsx
@@ -24,6 +24,10 @@ import {
   PageSectionSpacer,
   PageText,
 } from "#styles/common";
+import {
+  HTTP_STATUS_UNPROCESSABLE_CONTENT,
+  httpValidationErrorToString,
+} from "#utils/api";
 import { fieldContext, formContext } from "#utils/form";
 import { requiredStringValidator } from "#utils/validator";
 
@@ -60,6 +64,17 @@ function ModelEditorForm({
       void queryClient.invalidateQueries({
         queryKey: projectGetProjectQueryKey(),
       });
+    },
+    onError: (error) => {
+      if (error.response?.status === HTTP_STATUS_UNPROCESSABLE_CONTENT) {
+        const message = httpValidationErrorToString(error);
+        console.error(message);
+        toast.error(message);
+      }
+    },
+    meta: {
+      errorPrefix: "Error saving model information",
+      preventDefaultErrorHandling: [HTTP_STATUS_UNPROCESSABLE_CONTENT],
     },
   });
 


### PR DESCRIPTION
Resolves #139 

PR to use the same validation pattern for model and access fields as used in the masterdata fields.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
