### PR TITLE
ENH: Enable setting model description

### DIFF
--- a/frontend/src/components/form/field.tsx
+++ b/frontend/src/components/form/field.tsx
@@ -35,6 +35,8 @@ const helperTextLoadingOptions = "Loading options...";
 
 export function TextField({
   label,
+  multiline = false,
+  rows,
   placeholder,
   helperText,
   isReadOnly,
@@ -42,6 +44,8 @@ export function TextField({
   setSubmitDisabled,
 }: {
   label: string;
+  multiline?: boolean;
+  rows?: number;
   placeholder?: string;
   helperText?: string;
   isReadOnly?: boolean;
@@ -68,6 +72,8 @@ export function TextField({
         id={field.name}
         name={field.name}
         label={label}
+        multiline={multiline}
+        rows={rows}
         readOnly={isReadOnly}
         value={field.state.value}
         placeholder={placeholder}

--- a/frontend/src/components/project/overview/Model.tsx
+++ b/frontend/src/components/project/overview/Model.tsx
@@ -82,6 +82,9 @@ function ModelEditorForm({
     defaultValues: {
       modelName: modelData?.name ?? "",
       modelRevision: modelData?.revision ?? "",
+      modelDescription: modelData?.description
+        ? modelData.description.join("\n") // The description is an array of strings.
+        : "",
     },
 
     onSubmit: ({ value, formApi }) => {
@@ -90,6 +93,9 @@ function ModelEditorForm({
           body: {
             name: value.modelName.trim(),
             revision: value.modelRevision.trim(),
+            description: value.modelDescription
+              ? [value.modelDescription.trim()]
+              : undefined,
           },
         },
         {
@@ -103,7 +109,7 @@ function ModelEditorForm({
   });
 
   return (
-    <EditDialog open={isDialogOpen}>
+    <EditDialog open={isDialogOpen} $minWidth="32em">
       <form
         onSubmit={(e) => {
           e.preventDefault();
@@ -134,6 +140,14 @@ function ModelEditorForm({
             }}
           >
             {(field) => <field.TextField label="Revision" />}
+          </form.AppField>
+
+          <PageSectionSpacer />
+
+          <form.AppField name="modelDescription">
+            {(field) => (
+              <field.TextField label="Description" multiline={true} rows={5} />
+            )}
           </form.AppField>
         </Dialog.Content>
 
@@ -173,6 +187,16 @@ function ModelInfo({ modelData }: { modelData: Model }) {
           <tr>
             <th>Revision</th>
             <td>{modelData.revision}</td>
+          </tr>
+          <tr>
+            <th>Description</th>
+            <td>
+              {modelData.description ? (
+                <span className="multilineValue">{modelData.description}</span>
+              ) : (
+                <span className="missingValue">none</span>
+              )}
+            </td>
           </tr>
         </tbody>
       </table>

--- a/frontend/src/styles/common.ts
+++ b/frontend/src/styles/common.ts
@@ -51,6 +51,15 @@ export const InfoBox = styled.div`
   td {
     vertical-align: top;
   }
+
+  .missingValue {
+    color: ${tokens.colors.text.static_icons__tertiary.hex};
+    font-style: italic;
+  }
+
+  .multilineValue {
+    white-space: pre-line;
+  }
 `;
 
 export const ChipsContainer = styled.div`


### PR DESCRIPTION
Resolves #138 

PR to enable setting a model description.

Currently using the `TextField` component with `multipline` true. However in Eds in v2.0.0 this has been replaced by the `Textarea` component instead. Will make an issue to replace this once we upgrade. 

<img width="50%"  alt="image" src="https://github.com/user-attachments/assets/3e6f8796-e1dc-4030-bf0a-bd4fe7799552" />


## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
