### PR TITLE
ENH: Add option to set RMS project

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -20,6 +20,7 @@ export function Sidebar() {
 
   const ProjectSubItems: AccordianSubItem[] = [];
   if (project.status) {
+    ProjectSubItems.push({ label: "RMS", to: "/project/rms" });
     ProjectSubItems.push({ label: "Masterdata", to: "/project/masterdata" });
   }
 

--- a/frontend/src/components/project/overview/ProjectSelector.tsx
+++ b/frontend/src/components/project/overview/ProjectSelector.tsx
@@ -18,6 +18,7 @@ import { toast } from "react-toastify";
 import {
   projectGetLockStatusQueryKey,
   projectGetProjectQueryKey,
+  projectGetRmsProjectsQueryKey,
   projectPostInitProjectMutation,
   projectPostProjectMutation,
   userGetUserOptions,
@@ -80,6 +81,9 @@ function ProjectSelectorForm({
       });
       void queryClient.invalidateQueries({
         queryKey: projectGetLockStatusQueryKey(),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: projectGetRmsProjectsQueryKey(),
       });
       void queryClient.invalidateQueries({
         queryKey: userGetUserQueryKey(),

--- a/frontend/src/components/project/rms/Overview.tsx
+++ b/frontend/src/components/project/rms/Overview.tsx
@@ -1,0 +1,245 @@
+import { Dialog } from "@equinor/eds-core-react";
+import { createFormHook } from "@tanstack/react-form";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { toast } from "react-toastify";
+
+import { FmuProject, RmsProject } from "#client";
+import {
+  projectGetProjectQueryKey,
+  projectGetRmsProjectsOptions,
+  projectPatchRmsMutation,
+} from "#client/@tanstack/react-query.gen";
+import {
+  CancelButton,
+  GeneralButton,
+  SubmitButton,
+} from "#components/form/button";
+import { OptionProps, Select } from "#components/form/field";
+import { EditDialog, InfoBox, PageCode, PageText } from "#styles/common";
+import {
+  HTTP_STATUS_UNPROCESSABLE_CONTENT,
+  httpValidationErrorToString,
+} from "#utils/api";
+import { fieldContext, formContext } from "#utils/form";
+import { getRmsProjectName } from "#utils/model";
+
+const { useAppForm: useAppFormRmsEditor } = createFormHook({
+  fieldComponents: {
+    Select,
+  },
+  formComponents: {
+    SubmitButton,
+    CancelButton,
+  },
+  fieldContext,
+  formContext,
+});
+
+function getProjectOptionFromPath(path: string) {
+  return {
+    label: getRmsProjectName(path),
+    value: path,
+  };
+}
+
+function RmsEditorForm({
+  rmsData,
+  isDialogOpen,
+  setIsDialogOpen,
+}: {
+  rmsData: RmsProject | null | undefined;
+  isDialogOpen: boolean;
+  setIsDialogOpen: (open: boolean) => void;
+}) {
+  const closeDialog = ({ formReset }: { formReset: () => void }) => {
+    formReset();
+    setIsDialogOpen(false);
+  };
+
+  const queryClient = useQueryClient();
+
+  const { data: RmsProjectOptions, isPending: isRmsProjectOptionsPending } =
+    useQuery(projectGetRmsProjectsOptions());
+
+  const { mutate, isPending } = useMutation({
+    ...projectPatchRmsMutation(),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: projectGetProjectQueryKey(),
+      });
+    },
+    onError: (error) => {
+      if (error.response?.status === HTTP_STATUS_UNPROCESSABLE_CONTENT) {
+        const message = httpValidationErrorToString(error);
+        console.error(message);
+        toast.error(message);
+      }
+    },
+    meta: {
+      errorPrefix: "Error saving the RMS project",
+      preventDefaultErrorHandling: [HTTP_STATUS_UNPROCESSABLE_CONTENT],
+    },
+  });
+
+  const form = useAppFormRmsEditor({
+    defaultValues: {
+      rmsPath: rmsData?.path ?? "",
+    },
+
+    onSubmit: ({ value, formApi }) => {
+      mutate(
+        {
+          body: {
+            path: value.rmsPath,
+          },
+        },
+        {
+          onSuccess: () => {
+            toast.info("Successfully set the RMS project");
+            closeDialog({ formReset: formApi.reset });
+          },
+        },
+      );
+    },
+  });
+
+  const availableRmsProjects = RmsProjectOptions?.results ?? [];
+
+  function isProjectInAvailable(path: string) {
+    return availableRmsProjects.some((option) => option.path === path);
+  }
+
+  const projectOptions: OptionProps[] = availableRmsProjects.map((option) =>
+    getProjectOptionFromPath(option.path),
+  );
+  if (!rmsData) {
+    projectOptions.unshift({ label: "(none)", value: "" });
+  } else if (!isProjectInAvailable(rmsData.path)) {
+    projectOptions.unshift(getProjectOptionFromPath(rmsData.path));
+  }
+
+  return (
+    <EditDialog open={isDialogOpen} $minWidth="32em">
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          void form.handleSubmit();
+        }}
+      >
+        <Dialog.Header>
+          <Dialog.Title>RMS project</Dialog.Title>
+        </Dialog.Header>
+
+        <Dialog.Content>
+          <form.AppField
+            name="rmsPath"
+            validators={{
+              onMount: () =>
+                availableRmsProjects.length === 0
+                  ? "Could not detect any RMS projects in the rms/model directory"
+                  : rmsData && !isProjectInAvailable(rmsData.path)
+                    ? "Selected project does not exist"
+                    : undefined,
+
+              onChange: ({ value }) =>
+                !isProjectInAvailable(value)
+                  ? "Selected project does not exist"
+                  : undefined,
+            }}
+          >
+            {(field) => {
+              return (
+                <field.Select
+                  label="RMS project"
+                  value={field.state.value}
+                  options={projectOptions}
+                  loadingOptions={isRmsProjectOptionsPending}
+                  onChange={(value) => {
+                    field.handleChange(value);
+                  }}
+                />
+              );
+            }}
+          </form.AppField>
+        </Dialog.Content>
+
+        <Dialog.Actions>
+          <form.Subscribe
+            selector={(state) => [state.isDefaultValue, state.canSubmit]}
+          >
+            {([isDefaultValue, canSubmit]) => (
+              <form.SubmitButton
+                label="Save"
+                disabled={isDefaultValue || !canSubmit}
+                isPending={isPending}
+                helperTextDisabled="Value can be submitted when it has been changed and is valid"
+              />
+            )}
+          </form.Subscribe>
+          <form.CancelButton
+            onClick={(e) => {
+              e.preventDefault();
+              closeDialog({ formReset: form.reset });
+            }}
+          />
+        </Dialog.Actions>
+      </form>
+    </EditDialog>
+  );
+}
+
+function RmsInfo({ rmsData }: { rmsData: RmsProject }) {
+  return (
+    <InfoBox>
+      <table>
+        <tbody>
+          <tr>
+            <th>Project</th>
+            <td>{getRmsProjectName(rmsData.path)}</td>
+          </tr>
+          <tr>
+            <th>Version</th>
+            <td>{rmsData.version}</td>
+          </tr>
+        </tbody>
+      </table>
+    </InfoBox>
+  );
+}
+
+export function Overview({ projectData }: { projectData: FmuProject }) {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const rmsData = projectData.config.rms;
+
+  return (
+    <>
+      <PageText>
+        The following is the main RMS project located in the <i>rms/model</i>{" "}
+        directory. The version is detected automatically:
+      </PageText>
+
+      {rmsData ? (
+        <RmsInfo rmsData={rmsData} />
+      ) : (
+        <PageCode>No RMS project information found in the project.</PageCode>
+      )}
+
+      <GeneralButton
+        label={"Select project"}
+        disabled={projectData.is_read_only}
+        tooltipText={projectData.is_read_only ? "Project is read-only" : ""}
+        onClick={() => {
+          setIsDialogOpen(true);
+        }}
+      />
+
+      <RmsEditorForm
+        rmsData={rmsData}
+        isDialogOpen={isDialogOpen}
+        setIsDialogOpen={setIsDialogOpen}
+      />
+    </>
+  );
+}

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as rootRoute } from "./routes/__root";
 import { Route as IndexImport } from "./routes/index";
 import { Route as ProjectIndexImport } from "./routes/project/index";
 import { Route as UserKeysImport } from "./routes/user/keys";
+import { Route as ProjectRmsImport } from "./routes/project/rms";
 import { Route as ProjectMasterdataImport } from "./routes/project/masterdata";
 
 // Create/Update Routes
@@ -33,6 +34,12 @@ const ProjectIndexRoute = ProjectIndexImport.update({
 const UserKeysRoute = UserKeysImport.update({
   id: "/user/keys",
   path: "/user/keys",
+  getParentRoute: () => rootRoute,
+} as any);
+
+const ProjectRmsRoute = ProjectRmsImport.update({
+  id: "/project/rms",
+  path: "/project/rms",
   getParentRoute: () => rootRoute,
 } as any);
 
@@ -60,6 +67,13 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof ProjectMasterdataImport;
       parentRoute: typeof rootRoute;
     };
+    "/project/rms": {
+      id: "/project/rms";
+      path: "/project/rms";
+      fullPath: "/project/rms";
+      preLoaderRoute: typeof ProjectRmsImport;
+      parentRoute: typeof rootRoute;
+    };
     "/user/keys": {
       id: "/user/keys";
       path: "/user/keys";
@@ -82,6 +96,7 @@ declare module "@tanstack/react-router" {
 export interface FileRoutesByFullPath {
   "/": typeof IndexRoute;
   "/project/masterdata": typeof ProjectMasterdataRoute;
+  "/project/rms": typeof ProjectRmsRoute;
   "/user/keys": typeof UserKeysRoute;
   "/project": typeof ProjectIndexRoute;
 }
@@ -89,6 +104,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   "/": typeof IndexRoute;
   "/project/masterdata": typeof ProjectMasterdataRoute;
+  "/project/rms": typeof ProjectRmsRoute;
   "/user/keys": typeof UserKeysRoute;
   "/project": typeof ProjectIndexRoute;
 }
@@ -97,22 +113,35 @@ export interface FileRoutesById {
   __root__: typeof rootRoute;
   "/": typeof IndexRoute;
   "/project/masterdata": typeof ProjectMasterdataRoute;
+  "/project/rms": typeof ProjectRmsRoute;
   "/user/keys": typeof UserKeysRoute;
   "/project/": typeof ProjectIndexRoute;
 }
 
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath;
-  fullPaths: "/" | "/project/masterdata" | "/user/keys" | "/project";
+  fullPaths:
+    | "/"
+    | "/project/masterdata"
+    | "/project/rms"
+    | "/user/keys"
+    | "/project";
   fileRoutesByTo: FileRoutesByTo;
-  to: "/" | "/project/masterdata" | "/user/keys" | "/project";
-  id: "__root__" | "/" | "/project/masterdata" | "/user/keys" | "/project/";
+  to: "/" | "/project/masterdata" | "/project/rms" | "/user/keys" | "/project";
+  id:
+    | "__root__"
+    | "/"
+    | "/project/masterdata"
+    | "/project/rms"
+    | "/user/keys"
+    | "/project/";
   fileRoutesById: FileRoutesById;
 }
 
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute;
   ProjectMasterdataRoute: typeof ProjectMasterdataRoute;
+  ProjectRmsRoute: typeof ProjectRmsRoute;
   UserKeysRoute: typeof UserKeysRoute;
   ProjectIndexRoute: typeof ProjectIndexRoute;
 }
@@ -120,6 +149,7 @@ export interface RootRouteChildren {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   ProjectMasterdataRoute: ProjectMasterdataRoute,
+  ProjectRmsRoute: ProjectRmsRoute,
   UserKeysRoute: UserKeysRoute,
   ProjectIndexRoute: ProjectIndexRoute,
 };
@@ -136,6 +166,7 @@ export const routeTree = rootRoute
       "children": [
         "/",
         "/project/masterdata",
+        "/project/rms",
         "/user/keys",
         "/project/"
       ]
@@ -145,6 +176,9 @@ export const routeTree = rootRoute
     },
     "/project/masterdata": {
       "filePath": "project/masterdata.tsx"
+    },
+    "/project/rms": {
+      "filePath": "project/rms.tsx"
     },
     "/user/keys": {
       "filePath": "user/keys.tsx"

--- a/frontend/src/routes/project/rms.tsx
+++ b/frontend/src/routes/project/rms.tsx
@@ -1,0 +1,33 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { Suspense } from "react";
+
+import { Loading } from "#components/common";
+import { Overview } from "#components/project/rms/Overview";
+import { useProject } from "#services/project";
+import { PageHeader, PageText } from "#styles/common";
+
+export const Route = createFileRoute("/project/rms")({
+  component: RouteComponent,
+});
+
+function Content() {
+  const project = useProject();
+
+  return project.status && project.data ? (
+    <Overview projectData={project.data} />
+  ) : (
+    <PageText>Project not set.</PageText>
+  );
+}
+
+function RouteComponent() {
+  return (
+    <>
+      <PageHeader>RMS</PageHeader>
+
+      <Suspense fallback={<Loading />}>
+        <Content />
+      </Suspense>
+    </>
+  );
+}

--- a/frontend/src/utils/model.ts
+++ b/frontend/src/utils/model.ts
@@ -31,3 +31,7 @@ export function emptyMasterdata(): Smda {
     stratigraphic_column: emptyIdentifierUuid() as StratigraphicColumn,
   };
 }
+
+export function getRmsProjectName(projectPath: string) {
+  return projectPath.split("rms/model/").pop() ?? "";
+}


### PR DESCRIPTION
Resolves #145 

PR to add the option to set an RMS project from the GUI. 
A new `RMS` sidebar entry was added as it is expected to contain more functionality in the future.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
