### PR TITLE
ENH: Add more project information on homepage

### DIFF
--- a/frontend/src/components/ProjectInfo.tsx
+++ b/frontend/src/components/ProjectInfo.tsx
@@ -1,0 +1,35 @@
+import { Typography } from "@equinor/eds-core-react";
+
+import { FmuProject } from "#client";
+import { InfoBox } from "#styles/common";
+
+export function ProjectInfoBox({
+  projectData,
+  extended,
+}: {
+  projectData: FmuProject;
+  extended?: boolean;
+}) {
+  const created_date = new Date(
+    projectData.config.created_at,
+  ).toLocaleDateString();
+
+  return (
+    <InfoBox>
+      <Typography variant="h3">{projectData.project_dir_name}</Typography>
+      <Typography token={{ fontSize: "14px" }}>
+        {projectData.path} <br /> Last modified{" "}
+        <span className="missingValue">unknown</span>{" "}
+        {/* TODO: Add last modified date*/}
+        {extended && (
+          <>
+            <br />
+            Created {created_date} by {projectData.config.created_by}
+            <br /> <br />
+            FMU settings version {projectData.config.version}
+          </>
+        )}
+      </Typography>
+    </InfoBox>
+  );
+}

--- a/frontend/src/components/ProjectStatus.style.ts
+++ b/frontend/src/components/ProjectStatus.style.ts
@@ -1,0 +1,56 @@
+import { tokens } from "@equinor/eds-tokens";
+import styled from "styled-components";
+
+export const ProjectStatusContainer = styled.div`
+  padding: ${tokens.spacings.comfortable.medium};
+  border: solid 1px ${tokens.colors.ui.background__medium.hex};
+  border-radius: ${tokens.shape.corners.borderRadius};
+  margin-bottom: ${tokens.spacings.comfortable.medium};
+  height: fit-content;
+`;
+
+export const ProjectStatusHeader = styled.div`
+  display: grid;
+  align-items: center; 
+  grid-template-columns: min-content 1fr auto;
+  gap: ${tokens.spacings.comfortable.medium};
+`;
+
+export const ProjectStatusIconContainer = styled.div<{
+  $variant: "success" | "warning" | "error";
+}>`
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 100px;
+  width: 40px;
+  height: 40px;
+
+  ${({ $variant }) => {
+    switch ($variant) {
+      case "success":
+        return `
+          background-color: ${tokens.colors.interactive.primary__hover_alt.hex};
+          color: ${tokens.colors.interactive.primary__resting.hex};
+        `;
+      case "warning":
+        return `
+          background-color: ${tokens.colors.interactive.warning__highlight.hex};
+          color: ${tokens.colors.interactive.warning__resting.hex};
+        `;
+      case "error":
+        return `
+          background-color: ${tokens.colors.interactive.danger__highlight.hex};
+          color: ${tokens.colors.interactive.danger__resting.hex};
+        `;
+    }
+  }}
+`;
+
+export const StatusChecksContainer = styled.div`
+  margin-top: ${tokens.spacings.comfortable.large};
+
+  td {
+      width: 100%;
+  }
+`;

--- a/frontend/src/components/ProjectStatus.tsx
+++ b/frontend/src/components/ProjectStatus.tsx
@@ -1,0 +1,174 @@
+import { Button, Icon, Tooltip, Typography } from "@equinor/eds-core-react";
+import {
+  check,
+  close,
+  error_outlined,
+  go_to,
+  thumbs_up,
+  warning_outlined,
+} from "@equinor/eds-icons";
+import { tokens } from "@equinor/eds-tokens";
+import { Link } from "@tanstack/react-router";
+
+import { FmuProject } from "#client/types.gen";
+import {
+  ProjectStatusContainer,
+  ProjectStatusHeader,
+  ProjectStatusIconContainer,
+  StatusChecksContainer,
+} from "./ProjectStatus.style";
+
+Icon.add({
+  warning_outlined,
+  close,
+  error_outlined,
+  check,
+  thumbs_up,
+  go_to,
+});
+
+type Status = "success" | "warning" | "error";
+
+type StatusCheck = {
+  description: string;
+  status: Status;
+};
+
+function doProjectStatusChecks(projectData: FmuProject) {
+  const has_masterdata = !!projectData.config.masterdata;
+  const has_access = !!projectData.config.access;
+  const has_model = !!projectData.config.model;
+
+  const checks: StatusCheck[] = [
+    {
+      description: "Masterdata is " + (has_masterdata ? "present" : "missing"),
+      status: has_masterdata ? "success" : "error",
+    },
+    {
+      description:
+        "Access information is " + (has_access ? "present" : "missing"),
+      status: has_access ? "success" : "error",
+    },
+    {
+      description:
+        "Model information is " + (has_model ? "present" : "missing"),
+      status: has_model ? "success" : "error",
+    },
+  ];
+
+  return checks;
+}
+
+function getIconForStatus(status: Status) {
+  switch (status) {
+    case "success":
+      return (
+        <Icon
+          name={"check"}
+          color={tokens.colors.interactive.success__resting.hex}
+        />
+      );
+    case "warning":
+      return (
+        <Icon
+          name={"warning_outlined"}
+          color={tokens.colors.interactive.warning__resting.hex}
+        />
+      );
+    case "error":
+      return (
+        <Icon
+          name={"close"}
+          color={tokens.colors.interactive.danger__resting.hex}
+        />
+      );
+  }
+}
+
+function StatusInfoTable({
+  statusChecks,
+  detailed = false,
+}: {
+  statusChecks: StatusCheck[];
+  detailed?: boolean;
+}) {
+  const order: Status[] = ["error", "warning", "success"];
+
+  return (
+    <StatusChecksContainer>
+      <table>
+        <tbody>
+          {statusChecks
+            .filter((check) => detailed || check.status !== "success")
+            .sort((a, b) => order.indexOf(a.status) - order.indexOf(b.status))
+            .map((check) => (
+              <tr key={check.description}>
+                <td>
+                  <Typography variant="cell_text" group="table">
+                    {check.description}
+                  </Typography>
+                </td>
+                <td>{getIconForStatus(check.status)}</td>
+              </tr>
+            ))}
+        </tbody>
+      </table>
+    </StatusChecksContainer>
+  );
+}
+
+export function ProjectStatus({
+  projectData,
+  detailed = false,
+}: {
+  projectData: FmuProject;
+  detailed?: boolean;
+}) {
+  const statusChecks = doProjectStatusChecks(projectData);
+
+  const hasError = statusChecks.some((check) => check.status === "error");
+  const hasWarning = statusChecks.some((check) => check.status === "warning");
+
+  const variant = hasError ? "error" : hasWarning ? "warning" : "success";
+
+  return (
+    <ProjectStatusContainer>
+      <ProjectStatusHeader>
+        <ProjectStatusIconContainer $variant={variant}>
+          <Icon
+            name={
+              hasError
+                ? "error_outlined"
+                : hasWarning
+                  ? "warning_outlined"
+                  : "thumbs_up"
+            }
+          />
+        </ProjectStatusIconContainer>
+
+        <div>
+          <Typography variant="h6">Project status</Typography>
+          <Typography token={{ fontSize: "14px" }}>
+            {hasError
+              ? "Some checks need attention"
+              : hasWarning
+                ? "Some checks may require review"
+                : "All checks passed"}
+          </Typography>
+        </div>
+
+        {!detailed && (
+          <Tooltip title="View details in project overview">
+            <Button variant="ghost_icon" as={Link} to="/project">
+              <Icon name="go_to" />
+            </Button>
+          </Tooltip>
+        )}
+      </ProjectStatusHeader>
+
+      {detailed && (
+        <StatusInfoTable statusChecks={statusChecks} detailed={true} />
+      )}
+    </ProjectStatusContainer>
+  );
+}

--- a/frontend/src/components/home/Resources.style.ts
+++ b/frontend/src/components/home/Resources.style.ts
@@ -3,14 +3,12 @@ import { tokens } from "@equinor/eds-tokens";
 import styled from "styled-components";
 
 export const ResourcesContainer = styled.div`
-  display: flex;
-  justify-content: flex-start;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
   gap: ${tokens.spacings.comfortable.medium};
 `;
 
 export const ResourceCard = styled(Card)`
-  width: 250px; 
   border: solid 1px ${tokens.colors.ui.background__medium.hex};
   background: ${tokens.colors.ui.background__light.hex};  
 `;

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,13 +1,39 @@
 import { createFileRoute } from "@tanstack/react-router";
 
+import { FmuProject } from "#client/types.gen";
 import { Resources } from "#components/home/Resources";
-import { PageHeader, PageSectionSpacer, PageText } from "#styles/common";
-
+import { ProjectInfoBox } from "#components/ProjectInfo";
+import { ProjectStatus } from "#components/ProjectStatus";
+import { ProjectSelector } from "#components/project/overview/ProjectSelector";
+import { useProject } from "#services/project";
+import {
+  InfoBox,
+  PageHeader,
+  PageSectionSpacer,
+  PageText,
+  ProjectInfoContainer,
+} from "#styles/common";
 export const Route = createFileRoute("/")({
   component: RouteComponent,
 });
 
+function ModelDescription({ projectData }: { projectData: FmuProject }) {
+  return (
+    <>
+      <PageHeader $variant="h6"> Model description</PageHeader>
+      <InfoBox>
+        <span className="multilineValue">
+          {projectData.config.model?.description ??
+            "No description found for the model. \nHead over to the project overview page to provide one!"}
+        </span>
+      </InfoBox>
+    </>
+  );
+}
+
 function RouteComponent() {
+  const project = useProject();
+
   return (
     <>
       <PageHeader>FMU Settings</PageHeader>
@@ -15,6 +41,22 @@ function RouteComponent() {
       <PageText $variant="ingress">
         This is an application for managing the settings of FMU projects.
       </PageText>
+
+      {project.data ? (
+        <>
+          <ProjectInfoContainer>
+            <ProjectInfoBox projectData={project.data} />
+            <ProjectStatus projectData={project.data} detailed={false} />
+          </ProjectInfoContainer>
+
+          <ModelDescription projectData={project.data} />
+        </>
+      ) : (
+        <>
+          <PageText>No project selected</PageText>
+          <ProjectSelector />
+        </>
+      )}
 
       <PageSectionSpacer />
 

--- a/frontend/src/routes/project/index.tsx
+++ b/frontend/src/routes/project/index.tsx
@@ -13,12 +13,15 @@ import {
   PageHeader,
   PageSectionSpacer,
   PageText,
+  ProjectInfoContainer,
 } from "#styles/common";
-import { displayDateTime } from "#utils/datetime";
-import { ProjectName } from "./index.style";
+
 export const Route = createFileRoute("/project/")({
   component: RouteComponent,
 });
+
+import { ProjectInfoBox } from "#components/ProjectInfo";
+import { ProjectStatus } from "#components/ProjectStatus";
 
 function ProjectInfo({
   projectData,
@@ -28,23 +31,17 @@ function ProjectInfo({
   lockStatus?: LockStatus;
 }) {
   return (
-    <>
-      <PageText>
-        Project: <ProjectName>{projectData.project_dir_name}</ProjectName>
-        <br />
-        Path: {projectData.path}
-        <br />
-        Created: {displayDateTime(projectData.config.created_at)} by{" "}
-        {projectData.config.created_by}
-        <br />
-        Version: {projectData.config.version}
-      </PageText>
+    <ProjectInfoContainer>
+      <div>
+        <ProjectInfoBox projectData={projectData} extended={true} />
+        <LockStatusBanner
+          lockStatus={lockStatus}
+          isReadOnly={projectData.is_read_only ?? true}
+        />
+      </div>
 
-      <LockStatusBanner
-        lockStatus={lockStatus}
-        isReadOnly={projectData.is_read_only ?? true}
-      />
-    </>
+      <ProjectStatus projectData={projectData} detailed={true} />
+    </ProjectInfoContainer>
   );
 }
 

--- a/frontend/src/styles/common.ts
+++ b/frontend/src/styles/common.ts
@@ -98,3 +98,9 @@ export const EditDialog = styled(Dialog).attrs<{
     margin-left: ${tokens.spacings.comfortable.small};
   }
 `;
+
+export const ProjectInfoContainer = styled.div`
+  display: grid;
+  grid-template-columns: 4fr 3fr;
+  gap: ${tokens.spacings.comfortable.medium};
+`;


### PR DESCRIPTION
Resolves #128 

PR to make the homepage more project oriented, by adding some information about the selected project

- display selected project or display the project selector if project is not selected from start
- show last modified information (note currently unavailable through the API) 
- show model description
- display project status indicator
   - does some simple checks that the required config values are set, and can be built upon in the future.
   - details is not shown on the homepage, but can be found on the project overview page
   
## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
