### PR TITLE
BUG: Reset masterdata editing data on dialog close

### DIFF
--- a/frontend/src/components/project/masterdata/Edit.tsx
+++ b/frontend/src/components/project/masterdata/Edit.tsx
@@ -149,6 +149,16 @@ const { useAppForm } = createFormHook({
   formComponents: { CancelButton, SubmitButton },
 });
 
+function resetEditData(
+  setProjectData: Dispatch<SetStateAction<FormMasterdataProject>>,
+  setAvailableData: Dispatch<SetStateAction<FormMasterdataBase>>,
+  setOrphanData: Dispatch<SetStateAction<FormMasterdataSub>>,
+) {
+  setProjectData(emptyFormMasterdataProject());
+  setAvailableData(emptyFormMasterdataBase());
+  setOrphanData(emptyFormMasterdataSub());
+}
+
 function handlePrepareEditData(
   masterdata: SmdaMasterdataResultGrouped,
   formApi: AnyFormApi,
@@ -557,7 +567,11 @@ export function Edit({
   }, [isOpen, projectMasterdata]);
 
   useEffect(() => {
-    if (smdaMasterdata.isSuccess && Object.keys(smdaMasterdata.data).length) {
+    if (
+      isOpen &&
+      smdaMasterdata.isSuccess &&
+      Object.keys(smdaMasterdata.data).length
+    ) {
       handlePrepareEditData(
         smdaMasterdata.data,
         form,
@@ -566,10 +580,17 @@ export function Edit({
         setOrphanData,
       );
     }
-  }, [form, form.setFieldMeta, smdaMasterdata.data, smdaMasterdata.isSuccess]);
+  }, [
+    form,
+    form.setFieldMeta,
+    isOpen,
+    smdaMasterdata.data,
+    smdaMasterdata.isSuccess,
+  ]);
 
   function handleClose({ formReset }: { formReset: () => void }) {
     formReset();
+    resetEditData(setProjectData, setAvailableData, setOrphanData);
     closeDialog();
   }
 
@@ -619,6 +640,7 @@ export function Edit({
   }: FormSubmitCallbackProps) => {
     toast.info(message);
     formReset();
+    resetEditData(setProjectData, setAvailableData, setOrphanData);
   };
 
   return (


### PR DESCRIPTION
Resolves #180 

When the edit masterdata dialog is closed, either by saving or by cancelling, the edit data (for project, available and orphans) are reset. When the dialog is opened again, this edit data is prepared again, with no data left over from the previous time the edit dialog was open.

## Checklist

- [ ] Tests added - not relevant
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [X Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
