### PR TITLE
ENH: Use only LockStatus to determine read-only status

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -61,14 +61,15 @@ function ProjectInfoItem({ label, value }: { label: string; value?: string }) {
 
 function ProjectInfo() {
   const project = useProject();
+  const lockStatus = project.lockStatus;
 
   return (
     <ProjectInfoContainer>
       {project.status && project.data ? (
         <>
           <LockStatusIcon
-            isReadOnly={project.data.is_read_only ?? true}
-            lockInfo={project.lockStatus?.lock_info}
+            isReadOnly={!(lockStatus?.is_lock_acquired ?? false)}
+            lockInfo={lockStatus?.lock_info}
           />
           <ProjectInfoItem
             label="Asset"

--- a/frontend/src/components/LockStatus.tsx
+++ b/frontend/src/components/LockStatus.tsx
@@ -106,6 +106,10 @@ function LockInfoTable({ lock_info }: { lock_info: LockInfo }) {
           <Table.Cell>Locked since</Table.Cell>
           <Table.Cell>{displayTimestamp(lock_info.acquired_at)}</Table.Cell>
         </Table.Row>
+        <Table.Row>
+          <Table.Cell>Expires at</Table.Cell>
+          <Table.Cell>{displayTimestamp(lock_info.expires_at)}</Table.Cell>
+        </Table.Row>
       </Table.Body>
     </Table>
   );
@@ -125,30 +129,16 @@ export function LockIcon({ isReadOnly }: { isReadOnly: boolean }) {
   );
 }
 
-export function LockStatusBanner({
-  lockStatus,
-  isReadOnly,
-}: {
-  lockStatus?: LockStatus;
-  isReadOnly: boolean;
-}) {
-  const queryClient = useQueryClient();
+export function LockStatusBanner({ lockStatus }: { lockStatus?: LockStatus }) {
+  const isReadOnly = !(lockStatus?.is_lock_acquired ?? false);
 
   useEffect(() => {
-    if (lockStatus && !lockStatus.lock_info) {
-      console.log(lockStatus);
-      if (isReadOnly) {
-        toast.info(
-          "Project can be opened for editing from the project overview page.",
-        );
-      } else {
-        toast.error("Lock was removed, project is now read-only.");
-        void queryClient.invalidateQueries({
-          queryKey: projectGetProjectQueryKey(),
-        });
-      }
+    if (lockStatus && !lockStatus.lock_info && isReadOnly) {
+      toast.info(
+        "Project is now read-only. It can be opened for editing from the project overview page.",
+      );
     }
-  }, [lockStatus, isReadOnly, queryClient]);
+  }, [lockStatus, isReadOnly]);
 
   return (
     <Banner>

--- a/frontend/src/components/project/overview/Access.tsx
+++ b/frontend/src/components/project/overview/Access.tsx
@@ -55,10 +55,12 @@ const { useAppForm: useAppFormAccessEditor } = createFormHook({
 
 function AccessEditorForm({
   accessData,
+  projectReadOnly,
   isDialogOpen,
   setIsDialogOpen,
 }: {
   accessData: Access | null | undefined;
+  projectReadOnly: boolean;
   isDialogOpen: boolean;
   setIsDialogOpen: (open: boolean) => void;
 }) {
@@ -179,8 +181,11 @@ function AccessEditorForm({
             {([isDefaultValue, canSubmit]) => (
               <form.SubmitButton
                 label="Save"
-                disabled={isDefaultValue || !canSubmit}
+                disabled={isDefaultValue || !canSubmit || projectReadOnly}
                 isPending={isPending}
+                helperTextDisabled={
+                  projectReadOnly ? "Project is read-only" : undefined
+                }
               />
             )}
           </form.Subscribe>
@@ -217,8 +222,10 @@ export function AccessInfo({ accessData }: { accessData: Access }) {
 
 export function EditableAccessInfo({
   projectData,
+  projectReadOnly,
 }: {
   projectData: FmuProject;
+  projectReadOnly: boolean;
 }) {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const accessData = projectData.config.access;
@@ -266,8 +273,8 @@ export function EditableAccessInfo({
 
       <GeneralButton
         label={accessData ? "Edit" : "Add"}
-        disabled={projectData.is_read_only}
-        tooltipText={projectData.is_read_only ? "Project is read-only" : ""}
+        disabled={projectReadOnly}
+        tooltipText={projectReadOnly ? "Project is read-only" : ""}
         onClick={() => {
           setIsDialogOpen(true);
         }}
@@ -275,6 +282,7 @@ export function EditableAccessInfo({
 
       <AccessEditorForm
         accessData={accessData}
+        projectReadOnly={projectReadOnly}
         isDialogOpen={isDialogOpen}
         setIsDialogOpen={setIsDialogOpen}
       />

--- a/frontend/src/components/project/overview/Model.tsx
+++ b/frontend/src/components/project/overview/Model.tsx
@@ -45,10 +45,12 @@ const { useAppForm: useAppFormModelEditor } = createFormHook({
 
 function ModelEditorForm({
   modelData,
+  projectReadOnly,
   isDialogOpen,
   setIsDialogOpen,
 }: {
   modelData: Model | null | undefined;
+  projectReadOnly: boolean;
   isDialogOpen: boolean;
   setIsDialogOpen: (open: boolean) => void;
 }) {
@@ -158,8 +160,11 @@ function ModelEditorForm({
             {([isDefaultValue, canSubmit]) => (
               <form.SubmitButton
                 label="Save"
-                disabled={isDefaultValue || !canSubmit}
+                disabled={isDefaultValue || !canSubmit || projectReadOnly}
                 isPending={isPending}
+                helperTextDisabled={
+                  projectReadOnly ? "Project is read-only" : undefined
+                }
               />
             )}
           </form.Subscribe>
@@ -206,8 +211,10 @@ function ModelInfo({ modelData }: { modelData: Model }) {
 
 export function EditableModelInfo({
   projectData,
+  projectReadOnly,
 }: {
   projectData: FmuProject;
+  projectReadOnly: boolean;
 }) {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const modelData = projectData.config.model;
@@ -233,8 +240,8 @@ export function EditableModelInfo({
 
       <GeneralButton
         label={modelData ? "Edit" : "Add"}
-        disabled={projectData.is_read_only}
-        tooltipText={projectData.is_read_only ? "Project is read-only" : ""}
+        disabled={projectReadOnly}
+        tooltipText={projectReadOnly ? "Project is read-only" : ""}
         onClick={() => {
           setIsDialogOpen(true);
         }}
@@ -242,6 +249,7 @@ export function EditableModelInfo({
 
       <ModelEditorForm
         modelData={modelData}
+        projectReadOnly={projectReadOnly}
         isDialogOpen={isDialogOpen}
         setIsDialogOpen={setIsDialogOpen}
       />

--- a/frontend/src/components/project/overview/ProjectSelector.tsx
+++ b/frontend/src/components/project/overview/ProjectSelector.tsx
@@ -55,9 +55,11 @@ const { useAppForm: useAppFormProjectSelectorForm } = createFormHook({
 type ValueSource = "recentProjectPath" | "projectPath" | "";
 
 function ProjectSelectorForm({
+  projectReadOnly,
   closeDialog,
   isDialogOpen,
 }: {
+  projectReadOnly: boolean;
   closeDialog: () => void;
   isDialogOpen: boolean;
 }) {
@@ -114,11 +116,8 @@ function ProjectSelectorForm({
       mutate(
         { body: { path } },
         {
-          onSuccess: (data) => {
-            toast.info(
-              `Successfully set project ${path}` +
-                (data.is_read_only ? " (read-only)" : ""),
-            );
+          onSuccess: () => {
+            toast.info(`Successfully set project ${path}`);
             closeProjectSelector({ formReset: formApi.reset });
           },
           onError: (error) => {
@@ -240,8 +239,11 @@ function ProjectSelectorForm({
           <form.AppForm>
             <form.SubmitButton
               label="Select"
-              disabled={submitDisabled}
+              disabled={submitDisabled || projectReadOnly}
               isPending={isPending}
+              helperTextDisabled={
+                projectReadOnly ? "Project is read-only" : undefined
+              }
             />
             <form.CancelButton
               onClick={() => {
@@ -367,7 +369,11 @@ function ConfirmInitProjectDialog({
   );
 }
 
-export function ProjectSelector() {
+export function ProjectSelector({
+  projectReadOnly,
+}: {
+  projectReadOnly: boolean;
+}) {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   const handleOpen = () => {
@@ -381,6 +387,7 @@ export function ProjectSelector() {
     <>
       <Button onClick={handleOpen}>Select project</Button>
       <ProjectSelectorForm
+        projectReadOnly={projectReadOnly}
         closeDialog={handleClose}
         isDialogOpen={isDialogOpen}
       />

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -71,7 +71,9 @@ function RouteComponent() {
         <>
           <PageText>No project selected</PageText>
 
-          <ProjectSelector />
+          <ProjectSelector
+            projectReadOnly={!(project.lockStatus?.is_lock_acquired ?? false)}
+          />
         </>
       )}
 

--- a/frontend/src/routes/project/index.tsx
+++ b/frontend/src/routes/project/index.tsx
@@ -63,10 +63,7 @@ function ProjectInfo({
     <>
       <ProjectInfoBox projectData={projectData} />
 
-      <LockStatusBanner
-        lockStatus={lockStatus}
-        isReadOnly={projectData.is_read_only ?? true}
-      />
+      <LockStatusBanner lockStatus={lockStatus} />
     </>
   );
 }
@@ -86,6 +83,7 @@ function ProjectNotFound({ text }: { text: string }) {
 
 function Content() {
   const project = useProject();
+  const projectReadOnly = !(project.lockStatus?.is_lock_acquired ?? false);
 
   return (
     <>
@@ -95,21 +93,27 @@ function Content() {
             projectData={project.data}
             lockStatus={project.lockStatus}
           />
-          <ProjectSelector />
+          <ProjectSelector projectReadOnly={projectReadOnly} />
 
           <PageSectionSpacer />
 
-          <EditableModelInfo projectData={project.data} />
+          <EditableModelInfo
+            projectData={project.data}
+            projectReadOnly={projectReadOnly}
+          />
 
           <PageSectionSpacer />
 
-          <EditableAccessInfo projectData={project.data} />
+          <EditableAccessInfo
+            projectData={project.data}
+            projectReadOnly={projectReadOnly}
+          />
         </>
       ) : (
         <>
           <ProjectNotFound text={project.text ?? ""} />
 
-          <ProjectSelector />
+          <ProjectSelector projectReadOnly={projectReadOnly} />
         </>
       )}
     </>


### PR DESCRIPTION
Resolves #174 

PR to use only data in the lock status to set the read-only state of the application, moving away from using the `project.is_read_only` attribute. 

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
