### PR TITLE
FIX: Compare fully resolved paths

### DIFF
--- a/src/fmu_settings_gui/__main__.py
+++ b/src/fmu_settings_gui/__main__.py
@@ -1,7 +1,6 @@
 """The main entry point for fmu-settings-gui."""
 
 import asyncio
-import os
 import re
 import signal
 import sys
@@ -24,14 +23,16 @@ async def serve_spa_catchall(full_path: str) -> FileResponse:
     """Ensures internal paths to the GUI are served by the SPA."""
     if full_path == "":
         full_path = "index.html"
-    resolved_path = os.path.normpath(
-        os.path.realpath(os.path.join(str(static_dir), full_path))
-    )
-    if bool(re.fullmatch(r"^[\w\s\.\-/]+$", str(resolved_path))) is False:
+
+    resolved_path = (static_dir / full_path).resolve()
+
+    if not re.fullmatch(r"^[\w\s\.\-/]+$", str(resolved_path)):
         raise ValueError(f"Unallowed characters present in {full_path!r}")
-    if not resolved_path.startswith(str(static_dir)):
+
+    if not resolved_path.is_relative_to(static_dir):
         raise HTTPException(status_code=403, detail="Access denied")
-    if os.path.exists(resolved_path):
+
+    if resolved_path.exists():
         return FileResponse(resolved_path)
     return FileResponse(static_dir / "index.html")
 


### PR DESCRIPTION
The Komodo installation will install some binary files into a lib64 directory, which is symlinked to lib. Because the static directory path was not fully resolved the comparison failed.

Resolves #124

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
