### PR TITLE
BUG: Remove default maxWidth for EditDialog

### DIFF
--- a/frontend/src/components/project/masterdata/Edit.tsx
+++ b/frontend/src/components/project/masterdata/Edit.tsx
@@ -142,7 +142,7 @@ function ConfirmItemsOperationDialog({
   }
 
   return (
-    <EditDialog open={isOpen} $minWidth="32em" $extraPaddingBottom={false}>
+    <EditDialog open={isOpen} $minWidth="32em">
       <Dialog.Header>
         <Dialog.Title>
           {selectedItems.operation === "addition" ? "Add" : "Remove"} items

--- a/frontend/src/styles/common.ts
+++ b/frontend/src/styles/common.ts
@@ -103,29 +103,30 @@ export const InfoChip = styled(Chip)`
   }
 `;
 
-export const EditDialog = styled(Dialog).attrs<{
+export const GenericDialog = styled(Dialog).attrs<{
   $minWidth?: string;
   $maxWidth?: string;
-  $extraPaddingBottom?: boolean;
-}>((props) => ({
+}>(({ $minWidth = "10em", $maxWidth = undefined }) => ({
   style: {
-    minWidth: props.$minWidth ?? "10em",
-    maxWidth: props.$maxWidth ?? "20em",
+    minWidth: $minWidth,
+    maxWidth: $maxWidth,
   },
 }))`
   width: 100%;
-  
+
   #eds-dialog-customcontent {
     min-height: auto;
     padding: ${tokens.spacings.comfortable.medium};
-    padding-bottom: ${(props) =>
-      props.$extraPaddingBottom !== undefined && !props.$extraPaddingBottom
-        ? undefined
-        : tokens.spacings.comfortable.x_large}
   }
 
   button + button {
     margin-left: ${tokens.spacings.comfortable.small};
+  }
+`;
+
+export const EditDialog = styled(GenericDialog)`
+  #eds-dialog-customcontent {
+    padding-bottom: ${tokens.spacings.comfortable.x_large};
   }
 `;
 


### PR DESCRIPTION
Resolves #132 and #253. 

Added a `GenericDialog `component and extended the padding bottom to `EditDialog`. 


## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
