### PR TITLE
ENH: Disable buttons when RMS is opening/closing

### DIFF
--- a/frontend/src/components/project/rms/Overview.style.ts
+++ b/frontend/src/components/project/rms/Overview.style.ts
@@ -5,6 +5,6 @@ export const ActionButtonsContainer = styled.div`
   margin-bottom: ${tokens.spacings.comfortable.medium};
 
   button + button {
-    margin-left: ${tokens.spacings.comfortable.small};
+    margin-left: ${tokens.spacings.comfortable.small} !important;
   }
 `;

--- a/frontend/src/components/project/rms/Overview.tsx
+++ b/frontend/src/components/project/rms/Overview.tsx
@@ -271,7 +271,11 @@ function RmsProjectActions({
       <ActionButtonsContainer>
         <GeneralButton
           label="Select project"
-          disabled={!!projectIsReadOnly || isRmsProjectOpen}
+          disabled={
+            !!projectIsReadOnly ||
+            isRmsProjectOpen ||
+            projectOpenMutation.isPending
+          }
           tooltipText={
             projectIsReadOnly
               ? "Project is read-only"
@@ -289,6 +293,7 @@ function RmsProjectActions({
             <GeneralButton
               label={isRmsProjectOpen ? "Reload project" : "Open project"}
               isPending={projectOpenMutation.isPending}
+              disabled={projectCloseMutation.isPending}
               variant={isRmsProjectOpen ? "outlined" : "contained"}
               onClick={() => {
                 projectOpenMutation.mutate({});


### PR DESCRIPTION
Resolves #196 

PR to
- prevent selecting a project while one is being opened
- prevent reloading a project while one is being closed


## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
