### PR TITLE
FIX: Invalidate RMS data when project is opened

### DIFF
--- a/frontend/src/components/project/rms/Overview.tsx
+++ b/frontend/src/components/project/rms/Overview.tsx
@@ -10,6 +10,8 @@ import {
   projectGetRmsProjectsOptions,
   projectPatchRmsMutation,
   rmsDeleteRmsProjectMutation,
+  rmsGetHorizonsQueryKey,
+  rmsGetZonesQueryKey,
   rmsPostRmsProjectMutation,
 } from "#client/@tanstack/react-query.gen";
 import {
@@ -228,12 +230,19 @@ function RmsProjectActions({
   setIsRmsProjectOpen: Dispatch<SetStateAction<boolean>>;
   isRmsProjectOpen: boolean;
 }) {
+  const queryClient = useQueryClient();
   const [selectProjectDialogOpen, setSelectProjectDialogOpen] = useState(false);
 
   const projectOpenMutation = useMutation({
     ...rmsPostRmsProjectMutation(),
     onSuccess: () => {
       setIsRmsProjectOpen(true);
+      void queryClient.invalidateQueries({
+        queryKey: rmsGetHorizonsQueryKey(),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: rmsGetZonesQueryKey(),
+      });
     },
     onError: () => {
       setIsRmsProjectOpen(false);


### PR DESCRIPTION
Resolves #195 

PR to ensure RMS data is up to date when a project is opened / reopened by invalidating relevant queries on successful open.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
