### PR TITLE
BUG: Set default type button

### DIFF
--- a/frontend/src/components/form/button.tsx
+++ b/frontend/src/components/form/button.tsx
@@ -14,7 +14,7 @@ type GeneralButtonProps = {
 } & Pick<ButtonProps, "variant" | "type">;
 
 export function GeneralButton({
-  type,
+  type = "button",
   variant,
   label,
   disabled,


### PR DESCRIPTION
Resolves #215 

Set defatult `type` to `button` for `GeneralButton`. 

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
