### PR TITLE
BUG: Fix duplicate toast when project turns read-only

### DIFF
--- a/frontend/src/components/LockStatus.tsx
+++ b/frontend/src/components/LockStatus.tsx
@@ -2,7 +2,7 @@ import { Button, Icon, Popover, Table } from "@equinor/eds-core-react";
 import { lock, lock_open } from "@equinor/eds-icons";
 import { tokens } from "@equinor/eds-tokens";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { toast } from "react-toastify";
 
 import {
@@ -35,12 +35,12 @@ function EnableEditingButton({ lockStatus }: { lockStatus?: LockStatus }) {
           {},
           {
             onSuccess: (data) => {
-              data.message === "Project lock acquired."
-                ? toast.info("Project is open for editing")
-                : toast.error(
-                    "An error occured and project remains read-only. " +
-                      (lockStatus?.last_lock_acquire_error ?? ""),
-                  );
+              if (data.message !== "Project lock acquired.") {
+                toast.error(
+                  "An error occured and project remains read-only. " +
+                    (lockStatus?.last_lock_acquire_error ?? ""),
+                );
+              }
             },
           },
         );
@@ -131,14 +131,6 @@ export function LockIcon({ isReadOnly }: { isReadOnly: boolean }) {
 
 export function LockStatusBanner({ lockStatus }: { lockStatus?: LockStatus }) {
   const isReadOnly = !(lockStatus?.is_lock_acquired ?? false);
-
-  useEffect(() => {
-    if (lockStatus && !lockStatus.lock_info && isReadOnly) {
-      toast.info(
-        "Project is now read-only. It can be opened for editing from the project overview page.",
-      );
-    }
-  }, [lockStatus, isReadOnly]);
 
   return (
     <Banner>


### PR DESCRIPTION
Resolves #199 

PR which moves and consolidates the toast logic for when the read-only status of the project changes into the `getProjectLockStatus` query function. This is done by comparing to the read-only status of the previous query data.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
