### PR TITLE
BUG: Silently refresh stale SMDA access token

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -40,8 +40,7 @@ import {
   responseInterceptorRejected,
   TokenStatus,
 } from "#utils/authentication";
-import { defaultErrorHandling } from "#utils/query";
-import { mutationRetry } from "#utils/query";
+import { defaultErrorHandling, mutationRetry } from "#utils/query";
 import { routeTree } from "./routeTree.gen";
 
 export interface RouterContext {
@@ -183,6 +182,8 @@ export function App() {
           apiTokenStatus.valid ?? false,
           setApiTokenStatus,
           setRequestSessionCreation,
+          msalInstance,
+          setAccessToken,
         ),
       );
       setHasResponseInterceptor(true);
@@ -194,7 +195,13 @@ export function App() {
         setHasResponseInterceptor(false);
       }
     };
-  }, [createSessionMutateAsync, apiToken, apiTokenStatus.valid]);
+  }, [
+    createSessionMutateAsync,
+    apiToken,
+    apiTokenStatus.valid,
+    msalInstance,
+    setAccessToken,
+  ]);
 
   useEffect(() => {
     async function callCreateSessionAsync() {


### PR DESCRIPTION
Resolves #243 

Extended the existing Axios response interceptor to handle 401 responses from the SMDA upstream API. When detected, the interceptor:

1. Calls MSAL's `acquireTokenSilent` to silently obtain a new access token using the existing refresh token
2. Patches the new token into the backend session
3. Retry the request

If the refresh token itself has also expired, the interceptor falls back to `acquireTokenRedirect`, sending the user to the Microsoft login page.

A `_retried` flag on the request config prevents infinite retry loops if the replayed request also fails.

Have tested this by manually changing access token to invalid token and temporarily catch 403 in the interceptor (invalid token gives 403 error) and confirmed that it retried the request with new token and get 200 back on field search

## Checklist

- [x] Tests added (if not, comment why) - not relevant
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅