### PR TITLE
MAINT: Refactor text and confirmation to GenericDialog

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -14,7 +14,7 @@ import fmuLogo from "#assets/fmu-logo.svg";
 import type { LockInfo } from "#client/types.gen";
 import { LockIcon } from "#components/LockStatus";
 import { useProject } from "#services/project";
-import { EditDialog, PageText } from "#styles/common";
+import { GenericDialog, PageText } from "#styles/common";
 import {
   FmuLogo,
   HeaderActionButton,
@@ -108,7 +108,7 @@ function FeedbackDialog() {
         Feedback <Icon data={comment} size={18} />
       </HeaderActionButton>
 
-      <EditDialog
+      <GenericDialog
         isDismissable={true}
         open={isOpen}
         onClose={closeDialog}
@@ -154,7 +154,7 @@ function FeedbackDialog() {
         <Dialog.Actions>
           <Button onClick={closeDialog}>Close</Button>
         </Dialog.Actions>
-      </EditDialog>
+      </GenericDialog>
     </>
   );
 }

--- a/frontend/src/components/project/masterdata/Edit.tsx
+++ b/frontend/src/components/project/masterdata/Edit.tsx
@@ -37,6 +37,7 @@ import type {
 import {
   ChipsContainer,
   EditDialog,
+  GenericDialog,
   InfoChip,
   PageHeader,
   PageList,
@@ -142,7 +143,7 @@ function ConfirmItemsOperationDialog({
   }
 
   return (
-    <EditDialog open={isOpen} $minWidth="32em">
+    <GenericDialog open={isOpen} $minWidth="32em">
       <Dialog.Header>
         <Dialog.Title>
           {selectedItems.operation === "addition" ? "Add" : "Remove"} items
@@ -221,7 +222,7 @@ function ConfirmItemsOperationDialog({
           }}
         />
       </Dialog.Actions>
-    </EditDialog>
+    </GenericDialog>
   );
 }
 

--- a/frontend/src/components/project/rms/Stratigraphy.tsx
+++ b/frontend/src/components/project/rms/Stratigraphy.tsx
@@ -25,7 +25,13 @@ import type {
   FormSubmitCallbackProps,
   MutationCallbackProps,
 } from "#components/form/form.tsx";
-import { EditDialog, PageCode, PageHeader, PageText } from "#styles/common";
+import {
+  EditDialog,
+  GenericDialog,
+  PageCode,
+  PageHeader,
+  PageText,
+} from "#styles/common";
 import {
   HTTP_STATUS_UNPROCESSABLE_CONTENT,
   httpValidationErrorToString,
@@ -62,7 +68,7 @@ function ConfirmActionDialog({
   };
 
   return (
-    <EditDialog open={!!confirmAction} $minWidth="25em">
+    <GenericDialog open={!!confirmAction} $minWidth="25em">
       <Dialog.Header>Confirm action</Dialog.Header>
 
       <Dialog.CustomContent>
@@ -85,7 +91,7 @@ function ConfirmActionDialog({
         />
         <CancelButton onClick={resetConfirmAction} />
       </Dialog.Actions>
-    </EditDialog>
+    </GenericDialog>
   );
 }
 


### PR DESCRIPTION
Resolves #267 

Changed the forms that are only used for texts and confirmation to use `GenericDialog` component. 

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
