### PR TITLE
BUG: Select button enable for read only project path

### DIFF
--- a/frontend/src/components/project/overview/ProjectSelector.tsx
+++ b/frontend/src/components/project/overview/ProjectSelector.tsx
@@ -55,11 +55,9 @@ const { useAppForm: useAppFormProjectSelectorForm } = createFormHook({
 type ValueSource = "recentProjectPath" | "projectPath" | "";
 
 function ProjectSelectorForm({
-  projectReadOnly,
   closeDialog,
   isDialogOpen,
 }: {
-  projectReadOnly: boolean;
   closeDialog: () => void;
   isDialogOpen: boolean;
 }) {
@@ -161,10 +159,6 @@ function ProjectSelectorForm({
     setHelperTextProjectPath("");
   }, [form.state.values.projectPath]);
 
-  const hasProjectSelected =
-    form.state.values.projectPath !== "" ||
-    form.state.values.recentProjectPath !== "";
-
   return (
     <EditDialog open={isDialogOpen} $minWidth="40em">
       <form
@@ -243,15 +237,9 @@ function ProjectSelectorForm({
           <form.AppForm>
             <form.SubmitButton
               label="Select"
-              disabled={
-                submitDisabled || (projectReadOnly && !hasProjectSelected)
-              }
+              disabled={submitDisabled}
               isPending={isPending}
-              helperTextDisabled={
-                projectReadOnly && !hasProjectSelected
-                  ? "Project is read-only"
-                  : undefined
-              }
+              helperTextDisabled="Select a recent project or enter a valid project path"
             />
             <form.CancelButton
               onClick={() => {
@@ -377,11 +365,7 @@ function ConfirmInitProjectDialog({
   );
 }
 
-export function ProjectSelector({
-  projectReadOnly,
-}: {
-  projectReadOnly: boolean;
-}) {
+export function ProjectSelector() {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   const handleOpen = () => {
@@ -395,7 +379,6 @@ export function ProjectSelector({
     <>
       <Button onClick={handleOpen}>Select project</Button>
       <ProjectSelectorForm
-        projectReadOnly={projectReadOnly}
         closeDialog={handleClose}
         isDialogOpen={isDialogOpen}
       />

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -70,9 +70,7 @@ function RouteComponent() {
         <>
           <PageText>No project selected</PageText>
 
-          <ProjectSelector
-            projectReadOnly={!(project.lockStatus?.is_lock_acquired ?? false)}
-          />
+          <ProjectSelector />
         </>
       )}
 

--- a/frontend/src/routes/project/index.tsx
+++ b/frontend/src/routes/project/index.tsx
@@ -93,7 +93,7 @@ function Content() {
             projectData={project.data}
             lockStatus={project.lockStatus}
           />
-          <ProjectSelector projectReadOnly={projectReadOnly} />
+          <ProjectSelector />
 
           <PageSectionSpacer />
 
@@ -113,7 +113,7 @@ function Content() {
         <>
           <ProjectNotFound text={project.text ?? ""} />
 
-          <ProjectSelector projectReadOnly={projectReadOnly} />
+          <ProjectSelector />
         </>
       )}
     </>


### PR DESCRIPTION
Resolves #270 

The button is enabled  even when the project is read only and the user put the project path. 

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
