### PR TITLE
BUG: Correct typo in setup.py develop cmdclass key

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ class SdistCommand(sdist):
 setup(
     cmdclass={
         "build_py": BuildPyCommand,
-        "develop:": DevelopCommand,
+        "develop": DevelopCommand,
         "sdist": SdistCommand,
     },
 )


### PR DESCRIPTION
Resolves #278 

The trailing colon made the key unrecognised by setuptools, causing `pip install -e .` to skip the frontend build for local development.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
