### PR TITLE
BUG: Prevent validation on initial API keys and onBlur on cancel

### DIFF
--- a/frontend/src/components/form/button.tsx
+++ b/frontend/src/components/form/button.tsx
@@ -11,6 +11,7 @@ type GeneralButtonProps = {
   disabled?: boolean;
   tooltipText?: string;
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  onMouseDown?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 } & Pick<ButtonProps, "variant" | "color" | "type">;
 
 export function GeneralButton({
@@ -22,6 +23,7 @@ export function GeneralButton({
   isPending,
   tooltipText,
   onClick,
+  onMouseDown,
 }: GeneralButtonProps) {
   return (
     <Tooltip title={tooltipText ?? ""}>
@@ -37,6 +39,7 @@ export function GeneralButton({
               }
             : onClick
         }
+        onMouseDown={onMouseDown}
       >
         {isPending && (
           <DotProgress
@@ -76,8 +79,10 @@ export function SubmitButton({
 
 export function CancelButton({
   onClick,
+  onMouseDown,
 }: {
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  onMouseDown?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }) {
   return (
     <GeneralButton
@@ -85,6 +90,7 @@ export function CancelButton({
       variant="outlined"
       label="Cancel"
       onClick={onClick}
+      onMouseDown={onMouseDown}
     />
   );
 }

--- a/frontend/src/components/form/form.tsx
+++ b/frontend/src/components/form/form.tsx
@@ -61,7 +61,7 @@ export function EditableTextFieldForm({
   const [isReadonly, setIsReadonly] = useState(true);
   const [submitDisabled, setSubmitDisabled] = useState(true);
 
-  const validator = handleValidator({ length, minLength });
+  const validator = handleValidator({ length, minLength, initialValue: value });
 
   const formSubmitCallback = ({
     message,
@@ -134,6 +134,10 @@ export function EditableTextFieldForm({
                   e.preventDefault();
                   form.reset();
                   setIsReadonly(true);
+                }}
+                onMouseDown={(e) => {
+                  // Prevent onBlur of the input field so validation message does not flash
+                  e.preventDefault();
                 }}
               />
             </>

--- a/frontend/src/utils/validator.ts
+++ b/frontend/src/utils/validator.ts
@@ -3,23 +3,35 @@ import z, { type ZodString } from "zod";
 export interface ValidatorProps {
   length?: number;
   minLength?: number;
+  initialValue?: string;
 }
 
-export function handleValidator({ length, minLength }: ValidatorProps) {
+export function handleValidator({
+  length,
+  minLength,
+  initialValue,
+}: ValidatorProps) {
   let validator: ZodString | undefined;
 
   if (length !== undefined) {
     validator = z
       .string()
-      .refine((val: string) => val === "" || val.length === length, {
-        error: `Value must be empty or exactly ${String(length)} characters long`,
-      });
+      .refine(
+        (val: string) =>
+          val === "" || val === initialValue || val.length === length,
+        {
+          error: `Value must be empty or exactly ${String(length)} characters long`,
+        },
+      );
   } else if (minLength !== undefined) {
     validator = z
       .string()
-      .refine((val) => val === "" || val.length >= minLength, {
-        error: `Value must be empty or at least ${String(minLength)} characters long`,
-      });
+      .refine(
+        (val) => val === "" || val === initialValue || val.length >= minLength,
+        {
+          error: `Value must be empty or at least ${String(minLength)} characters long`,
+        },
+      );
   }
 
   return validator;


### PR DESCRIPTION
Resolves #59

Problems:

1. When editing the SMDA subscription key, if a user clicked the field but didn't modify the masked secret string (e.g., ********), clicking elsewhere triggered an `onBlur` validation check. Zod saw the short **** string, flagged it as invalid length, and threw an error message.
2. When a user tried to click "Cancel" while the input was focused, the click down (mousedown) instantly triggered the input's `onBlur` event. This caused the validation error to appear before the click finished (briefly flashed).

Solutions:

1. Passed the initial masked string to the `handleValidator` and told Zod to consider the input valid if `val === initialValue`.
2. Add a mouse down event on Cancel button to not steal focus from the input field so `onBlur` will not be triggered when clicking the cancel button. The `onClick` will reset the form back to the stored value, and the validation trigger by `onBlur` will pass if the previously stored value is valid.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
