### PR TITLE
CD: Only run publish workflow on full releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish to PyPI
 
 on:
   release:
-    types: [published]
+    types: [released]
 
 permissions:
   contents: read


### PR DESCRIPTION
Resolves parts of https://github.com/equinor/atlas/issues/218

Only run publish workflow when we have created a full release, and not pre-releases. This is to prevent bleeding pre-releases of being published to PyPi.

We aim to create bleeding pre-releases of `fmu-settings-gui` nightly and point Komodo bleeding to the `bleeding` version of `fmu-settings-gui`.

## Checklist

- [ ] Tests added (if not, comment why): Only CD changes
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
