### PR TITLE
CD: Prerelease skips pypi release and uploads to gh

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish to PyPI
 
 on:
   release:
-    types: [released]
+    types: [published]
 
 permissions:
   contents: read
@@ -49,4 +49,10 @@ jobs:
       run: python -m build -vv
 
     - name: Publish package distributions to PyPI
+      if: ${{ !github.event.release.prerelease }}
       uses: pypa/gh-action-pypi-publish@release/v1
+    
+    - name: Upload package distributions to GitHub release
+      if: ${{ github.event.release.prerelease }}
+      run:
+        gh release upload ${{github.event.release.tag_name}} dist/* --clobber


### PR DESCRIPTION
Resolves parts of https://github.com/equinor/atlas/issues/218

When the `publish` workflow is triggered by a prerelease event, the built python distribution should not be published to PyPi, but instead uploaded to the GitHub release that triggered the event.

## Checklist

- [ ] Tests added (if not, comment why): Only CD changes
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
