### PR TITLE
CI: Add missing GH_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to PyPI
+name: Publish to PyPI or upload to bleeding release
 
 on:
   release:
@@ -56,3 +56,5 @@ jobs:
       if: ${{ github.event.release.prerelease }}
       run:
         gh release upload ${{github.event.release.tag_name}} dist/* --clobber
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Resolves parts of https://github.com/equinor/atlas/issues/218

Add missing GB_TOKEN to the gh cli command used to upload the built files to the bleeding release.

## Checklist

- [ ] Tests added (if not, comment why): Only CI changes
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
