### PR TITLE
CI: Set content write permission on job level

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,7 @@ jobs:
       url: https://pypi.org/p/fmu-settings-gui
     permissions:
       id-token: write
+      contents: write
 
     steps:
     - name: Checkout


### PR DESCRIPTION
Resolves parts of https://github.com/equinor/atlas/issues/218

Set contents `write` permission on job level

## Checklist

- [ ] Tests added (if not, comment why): Only CI change
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
