### PR TITLE
CI: Rename built .whl file to fixed name

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,6 +56,13 @@ jobs:
     - name: Upload package distributions to GitHub release
       if: ${{ github.event.release.prerelease }}
       run:
-        gh release upload ${{github.event.release.tag_name}} dist/* --clobber
+        dir_dist="dist/"
+        whl_file=$(find "$dir_dist" -maxdepth 1 -name "*.whl")
+
+        fixed_bleeding_name="fmu_settings_gui-bleeding.whl"
+        echo "Renaming .whl file to $fixed_bleeding_name"
+        mv "$whl_file" "$dir_dist$fixed_bleeding_name"
+
+        gh release upload ${{github.event.release.tag_name}} $dir_dist$fixed_bleeding_name --clobber
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Resolves parts of https://github.com/equinor/atlas/issues/218

Rename built .whl file to the fixed name `fmu_settings_gui-bleeding.whl`. In this way we make sure the .whl file will always have the same name, which will make it easy to download the file from a fixed path.

## Checklist

- [ ] Tests added (if not, comment why): Only change to CI
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
