### PR TITLE
BUG: Add missing | to run section

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,7 @@ jobs:
     
     - name: Upload package distributions to GitHub release
       if: ${{ github.event.release.prerelease }}
-      run:
+      run: |
         dir_dist="dist/"
         whl_file=$(find "$dir_dist" -maxdepth 1 -name "*.whl")
 


### PR DESCRIPTION
Fix bug in https://github.com/equinor/fmu-settings-gui/pull/304

Add missing `|` to `run` section in publish workflow.

## Checklist

- [ ] Tests added (if not, comment why): Only CI change
- [X] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [X] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [X] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
