### PR TITLE
REV: Added back TaskList in homepage

### DIFF
--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 
 import type { FmuProject } from "#client";
+import { TaskList } from "#components/home/TaskList";
 import { ProjectSelector } from "#components/project/overview/ProjectSelector";
 import { useProject } from "#services/project";
 import {
@@ -65,7 +66,10 @@ function RouteComponent() {
       </PageText>
 
       {project.data ? (
-        <ProjectInfoBox projectData={project.data} />
+        <>
+          <ProjectInfoBox projectData={project.data} />
+          <TaskList />
+        </>
       ) : (
         <>
           <PageText>No project selected</PageText>


### PR DESCRIPTION
Resolves #313 

Add back TaskList which was removed in this [commit](https://github.com/equinor/fmu-settings-gui/pull/252/changes/7a8137cec53f7fa5aaf8e8c89e651f8ea39902df#diff-76c525e44e2cbc13acdaecc89ba3d7137f124731e1308aa137a8de291300d3dc) in this [PR](https://github.com/equinor/fmu-settings-gui/pull/252) @nourinmohd (you removed TaskList as well when removing LockExpireDialog)

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
