### PR TITLE
MAINT: Remove fmu settings version from homepage

### DIFF
--- a/frontend/src/routes/project/index.tsx
+++ b/frontend/src/routes/project/index.tsx
@@ -45,8 +45,6 @@ function ProjectInfoBox({ projectData }: { projectData: FmuProject }) {
         ) : (
           <span className="missingValue">unknown</span>
         )}
-        <br />
-        Version: {projectData.config.version}
       </PageText>
     </InfoBox>
   );


### PR DESCRIPTION
Resolves #324 

Removed the fmu settings `Version` from the homepage project info box. 

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
