### PR TITLE
MAINT: Prevent autoselect for project

### DIFF
--- a/frontend/src/components/project/overview/ProjectSelector.tsx
+++ b/frontend/src/components/project/overview/ProjectSelector.tsx
@@ -77,6 +77,7 @@ function ProjectSelectorForm({
     sethelperTextRecentProjects("");
     setHelperTextProjectPath("");
     setValueSource("");
+    setSubmitDisabled(true);
     formReset();
     closeDialog();
   };
@@ -220,7 +221,6 @@ function ProjectSelectorForm({
               },
               onChange: () => {
                 setValueSource("recentProjectPath");
-                void form.handleSubmit();
               },
             }}
           >
@@ -228,6 +228,7 @@ function ProjectSelectorForm({
               <field.RecentProjectSelect
                 recentProjects={userData.recent_project_directories}
                 helperText={helperTextRecentProjects}
+                setSubmitDisabled={setSubmitDisabled}
               />
             )}
           </form.AppField>
@@ -295,9 +296,11 @@ function ProjectSelectorForm({
 function RecentProjectSelect({
   recentProjects,
   helperText,
+  setSubmitDisabled,
 }: {
   recentProjects: string[];
   helperText: string;
+  setSubmitDisabled: (disabled: boolean) => void;
 }) {
   const field = useFieldContext<string>();
   const disabledSelect = recentProjects.length === 0;
@@ -318,6 +321,7 @@ function RecentProjectSelect({
         value={disabledSelect ? [] : [field.state.value]}
         onChange={(e: ChangeEvent<HTMLSelectElement>) => {
           field.handleChange(e.target.value);
+          setSubmitDisabled(e.target.value.length === 0);
         }}
         onBlur={() => {
           field.handleBlur();


### PR DESCRIPTION
Resolves #334 

The user will now have to press the select button when switching between projects. 

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
