### PR TITLE
BUG: Retry SMDA requests after refreshing SSO token

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import {
   type EventMessage,
   EventType,
   InteractionRequiredAuthError,
+  InteractionType,
   PublicClientApplication,
 } from "@azure/msal-browser";
 import { MsalProvider, useMsal } from "@azure/msal-react";
@@ -298,18 +299,24 @@ export function App() {
             void acquireAndPatchSsoAccessToken();
           } else if (event.eventType === EventType.ACQUIRE_TOKEN_SUCCESS) {
             setAccessToken(payload.accessToken);
+            if (event.interactionType === InteractionType.Redirect) {
+              handleAddSsoAccessToken(
+                patchAccessTokenMutate,
+                payload.accessToken,
+              );
+            }
           }
         }
-
-        return () => {
-          if (id !== null) {
-            msalInstance.removeEventCallback(id);
-          }
-        };
       },
       [EventType.LOGIN_SUCCESS, EventType.ACQUIRE_TOKEN_SUCCESS],
     );
-  }, [acquireAndPatchSsoAccessToken, msalInstance]);
+
+    return () => {
+      if (id !== null) {
+        msalInstance.removeEventCallback(id);
+      }
+    };
+  }, [acquireAndPatchSsoAccessToken, msalInstance, patchAccessTokenMutate]);
 
   return (
     <RouterProvider

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -22,6 +22,7 @@ import {
   StrictMode,
   useCallback,
   useEffect,
+  useRef,
   useState,
 } from "react";
 import ReactDOM from "react-dom/client";
@@ -175,6 +176,9 @@ export function App() {
   >();
   const [requestAcquireSsoAccessToken, setRequestAcquireSsoAccessToken] =
     useState(false);
+  const acquireAndPatchSsoAccessTokenPromise = useRef<
+    Promise<void> | undefined
+  >(undefined);
 
   const { mutateAsync: createSessionMutateAsync } = useMutation({
     ...sessionPostSessionMutation(),
@@ -194,20 +198,26 @@ export function App() {
   });
 
   const acquireAndPatchSsoAccessToken = useCallback(async () => {
-    const result = await msalInstance
-      .acquireTokenSilent({ scopes: ssoScopes })
-      .catch((error: unknown) => {
-        if (error instanceof InteractionRequiredAuthError) {
-          return msalInstance.acquireTokenRedirect({ scopes: ssoScopes });
-        }
-      });
+    acquireAndPatchSsoAccessTokenPromise.current ??= (async () => {
+      const result = await msalInstance
+        .acquireTokenSilent({ scopes: ssoScopes })
+        .catch((error: unknown) => {
+          if (error instanceof InteractionRequiredAuthError) {
+            return msalInstance.acquireTokenRedirect({ scopes: ssoScopes });
+          }
+        });
 
-    if (result) {
-      setAccessToken(result.accessToken);
-      await patchAccessTokenMutateAsync({
-        body: { id: "smda_api", key: result.accessToken },
-      });
-    }
+      if (result) {
+        setAccessToken(result.accessToken);
+        await patchAccessTokenMutateAsync({
+          body: { id: "smda_api", key: result.accessToken },
+        });
+      }
+    })().finally(() => {
+      acquireAndPatchSsoAccessTokenPromise.current = undefined;
+    });
+
+    await acquireAndPatchSsoAccessTokenPromise.current;
   }, [msalInstance, patchAccessTokenMutateAsync]);
 
   useEffect(() => {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -20,6 +20,7 @@ import {
   type Dispatch,
   type SetStateAction,
   StrictMode,
+  useCallback,
   useEffect,
   useState,
 } from "react";
@@ -179,7 +180,10 @@ export function App() {
     ...sessionPostSessionMutation(),
     meta: { errorPrefix: "Error creating session" },
   });
-  const { mutate: patchAccessTokenMutate } = useMutation({
+  const {
+    mutate: patchAccessTokenMutate,
+    mutateAsync: patchAccessTokenMutateAsync,
+  } = useMutation({
     ...sessionPatchAccessTokenMutation(),
     onSuccess: () => {
       void queryClient.invalidateQueries({
@@ -188,6 +192,23 @@ export function App() {
     },
     meta: { errorPrefix: "Error adding access token to session" },
   });
+
+  const acquireAndPatchSsoAccessToken = useCallback(async () => {
+    const result = await msalInstance
+      .acquireTokenSilent({ scopes: ssoScopes })
+      .catch((error: unknown) => {
+        if (error instanceof InteractionRequiredAuthError) {
+          return msalInstance.acquireTokenRedirect({ scopes: ssoScopes });
+        }
+      });
+
+    if (result) {
+      setAccessToken(result.accessToken);
+      await patchAccessTokenMutateAsync({
+        body: { id: "smda_api", key: result.accessToken },
+      });
+    }
+  }, [msalInstance, patchAccessTokenMutateAsync]);
 
   useEffect(() => {
     let id: number | undefined;
@@ -203,7 +224,7 @@ export function App() {
           apiTokenStatus.valid ?? false,
           setApiTokenStatus,
           setRequestSessionCreation,
-          setRequestAcquireSsoAccessToken,
+          acquireAndPatchSsoAccessToken,
         ),
       );
       setHasResponseInterceptor(true);
@@ -215,7 +236,7 @@ export function App() {
         setHasResponseInterceptor(false);
       }
     };
-  }, [apiToken, apiTokenStatus.valid]);
+  }, [acquireAndPatchSsoAccessToken, apiToken, apiTokenStatus.valid]);
 
   useEffect(() => {
     async function callCreateSessionAsync() {
@@ -246,16 +267,10 @@ export function App() {
 
   useEffect(() => {
     if (requestAcquireSsoAccessToken) {
-      msalInstance
-        .acquireTokenSilent({ scopes: ssoScopes })
-        .catch((error: unknown) => {
-          if (error instanceof InteractionRequiredAuthError) {
-            return msalInstance.acquireTokenRedirect({ scopes: ssoScopes });
-          }
-        });
+      void acquireAndPatchSsoAccessToken();
       setRequestAcquireSsoAccessToken(false);
     }
-  }, [msalInstance, requestAcquireSsoAccessToken]);
+  }, [acquireAndPatchSsoAccessToken, requestAcquireSsoAccessToken]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: Invalidate router context when some of the content changes
   useEffect(() => {
@@ -270,21 +285,9 @@ export function App() {
           if (event.eventType === EventType.LOGIN_SUCCESS) {
             const account = payload.account;
             msalInstance.setActiveAccount(account);
-            msalInstance
-              .acquireTokenSilent({ scopes: ssoScopes })
-              .catch((error: unknown) => {
-                if (error instanceof InteractionRequiredAuthError) {
-                  return msalInstance.acquireTokenRedirect({
-                    scopes: ssoScopes,
-                  });
-                }
-              });
+            void acquireAndPatchSsoAccessToken();
           } else if (event.eventType === EventType.ACQUIRE_TOKEN_SUCCESS) {
             setAccessToken(payload.accessToken);
-            handleAddSsoAccessToken(
-              patchAccessTokenMutate,
-              payload.accessToken,
-            );
           }
         }
 
@@ -296,7 +299,7 @@ export function App() {
       },
       [EventType.LOGIN_SUCCESS, EventType.ACQUIRE_TOKEN_SUCCESS],
     );
-  }, [msalInstance, patchAccessTokenMutate]);
+  }, [acquireAndPatchSsoAccessToken, msalInstance]);
 
   return (
     <RouterProvider

--- a/frontend/src/utils/authentication.ts
+++ b/frontend/src/utils/authentication.ts
@@ -7,6 +7,7 @@ import type {
   AxiosError,
   AxiosResponse,
   AxiosResponseHeaders,
+  InternalAxiosRequestConfig,
   RawAxiosResponseHeaders,
 } from "axios";
 import type { Dispatch, SetStateAction } from "react";
@@ -19,6 +20,7 @@ import type {
   SessionPostSessionData,
   SessionResponse,
 } from "#client";
+import { client } from "#client/client.gen";
 import { ssoScopes } from "#config";
 import { HTTP_STATUS_UNAUTHORIZED } from "./api";
 import {
@@ -146,6 +148,10 @@ export const responseInterceptorFulfilled =
     return response;
   };
 
+type RetryableRequestConfig = InternalAxiosRequestConfig & {
+  _retried?: boolean;
+};
+
 export const responseInterceptorRejected =
   (
     apiToken: string,
@@ -153,7 +159,7 @@ export const responseInterceptorRejected =
     apiTokenStatusValid: boolean,
     setApiTokenStatus: Dispatch<SetStateAction<TokenStatus>>,
     setRequestSessionCreation: Dispatch<SetStateAction<boolean>>,
-    setRequestAcquireSsoAccessToken: Dispatch<SetStateAction<boolean>>,
+    acquireAndPatchSsoAccessToken: () => Promise<void>,
   ) =>
   async (error: AxiosError) => {
     if (error.status === HTTP_STATUS_UNAUTHORIZED) {
@@ -167,7 +173,13 @@ export const responseInterceptorRejected =
         }
       } else if (isExternalApi(error.response?.headers)) {
         if (!isApiUrlSmdaHealthcheck(error.response?.config.url)) {
-          setRequestAcquireSsoAccessToken(true);
+          const config = error.config as RetryableRequestConfig | undefined;
+          if (config && !config._retried) {
+            config._retried = true;
+            await acquireAndPatchSsoAccessToken();
+
+            return await client.instance(config);
+          }
         }
       } else {
         setRequestSessionCreation(true);


### PR DESCRIPTION
Resolves #346 

Fixes stale SMDA SSO token requests by refreshing the token, patching it into the backend session, then retrying the failed request once.

I also moved the token refresh + session patching into one shared helper in `main.tsx`, so we keep the #275 idea of handling SSO token logic centrally. This avoids patching the same SSO token multiple times because the `ACQUIRE_TOKEN_SUCCESS` handler now only updates local state, while the shared helper handles the backend session patch.

Have tested this by changing the token manually and call the field search in masterdata again, it refreshed the token and retried the failed request automatically.

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
