### PR TITLE
BUG:Pressing ESC closes topmost dialog

### DIFF
--- a/frontend/src/components/project/masterdata/Edit.tsx
+++ b/frontend/src/components/project/masterdata/Edit.tsx
@@ -609,7 +609,7 @@ export function Edit({
 
       <EditDialog
         open={isOpen}
-        isDismissable={true}
+        isDismissable={!searchDialogOpen}
         onClose={handleCloseRequest}
         $maxWidth="200em"
       >

--- a/frontend/src/components/project/masterdata/FieldSearch.tsx
+++ b/frontend/src/components/project/masterdata/FieldSearch.tsx
@@ -9,7 +9,6 @@ import { type Dispatch, type SetStateAction, useEffect, useState } from "react";
 
 import type { SmdaFieldSearchResult, SmdaFieldUuid } from "#client";
 import { smdaPostFieldOptions } from "#client/@tanstack/react-query.gen";
-import { ConfirmCloseDialog } from "#components/common";
 import { CancelButton, GeneralButton } from "#components/form/button";
 import { SearchFieldForm } from "#components/form/form";
 import { EditDialog, PageSectionSpacer, PageText } from "#styles/common";
@@ -107,7 +106,6 @@ export function FieldSearch({
 }) {
   const [searchValue, setSearchValue] = useState("");
   const [selectedFields, setSelectedFields] = useState<Array<string>>([]);
-  const [confirmCloseDialogOpen, setConfirmCloseDialogOpen] = useState(false);
 
   const { data } = useQuery({
     ...smdaPostFieldOptions({ body: { identifier: searchValue } }),
@@ -116,33 +114,7 @@ export function FieldSearch({
 
   function handleClose() {
     setSearchValue("");
-    setSelectedFields([]);
-    setConfirmCloseDialogOpen(false);
     closeDialog();
-  }
-
-  function handleCloseRequest() {
-    // If there are selected fields, ask for confirmation
-    if (selectedFields.length > 0) {
-      setConfirmCloseDialogOpen(true);
-    } else {
-      handleClose();
-    }
-  }
-
-  // Reset confirm dialog when dialog closes
-  useEffect(() => {
-    if (!isOpen) {
-      setConfirmCloseDialogOpen(false);
-    }
-  }, [isOpen]);
-
-  function handleConfirmCloseDecision(confirm: boolean) {
-    if (confirm) {
-      handleClose();
-    } else {
-      setConfirmCloseDialogOpen(false);
-    }
   }
 
   const setStateCallback = (value: string) => {
@@ -150,50 +122,38 @@ export function FieldSearch({
   };
 
   return (
-    <>
-      <EditDialog
-        open={isOpen}
-        isDismissable={true}
-        onClose={handleCloseRequest}
-        $maxWidth="200em"
-      >
-        <Dialog.Header>Field search</Dialog.Header>
+    <EditDialog
+      open={isOpen}
+      isDismissable={true}
+      onClose={handleClose}
+      $maxWidth="200em"
+    >
+      <Dialog.Header>Field search</Dialog.Header>
 
-        <Dialog.CustomContent>
-          <SearchFormContainer>
-            <SearchFieldForm
-              name="identifier"
-              value={searchValue}
-              helperText="Tip: Use * as a wildcard for finding fields that start with the name. Example: OSEBERG*"
-              setStateCallback={setStateCallback}
-            />
-          </SearchFormContainer>
-
-          <FieldResults data={data} setSelectedFields={setSelectedFields} />
-        </Dialog.CustomContent>
-
-        <Dialog.Actions>
-          <GeneralButton
-            label="Add fields"
-            disabled={selectedFields.length === 0}
-            onClick={() => {
-              addFields(selectedFields);
-              handleClose();
-            }}
+      <Dialog.CustomContent>
+        <SearchFormContainer>
+          <SearchFieldForm
+            name="identifier"
+            value={searchValue}
+            helperText="Tip: Use * as a wildcard for finding fields that start with the name. Example: OSEBERG*"
+            setStateCallback={setStateCallback}
           />
-          <CancelButton onClick={handleCloseRequest} />
-        </Dialog.Actions>
-      </EditDialog>
+        </SearchFormContainer>
 
-      <ConfirmCloseDialog
-        isOpen={confirmCloseDialogOpen}
-        handleConfirmCloseDecision={handleConfirmCloseDecision}
-        title="Discard search results"
-        description="You have selected fields that haven't been added to the masterdata yet."
-        question="Do you want to discard the selected fields and close the search dialog?"
-        confirmLabel="Keep editing"
-        cancelLabel="Discard and close"
-      />
-    </>
+        <FieldResults data={data} setSelectedFields={setSelectedFields} />
+      </Dialog.CustomContent>
+
+      <Dialog.Actions>
+        <GeneralButton
+          label="Add fields"
+          disabled={selectedFields.length === 0}
+          onClick={() => {
+            addFields(selectedFields);
+            handleClose();
+          }}
+        />
+        <CancelButton onClick={handleClose} />
+      </Dialog.Actions>
+    </EditDialog>
   );
 }

--- a/frontend/src/components/project/masterdata/FieldSearch.tsx
+++ b/frontend/src/components/project/masterdata/FieldSearch.tsx
@@ -9,6 +9,7 @@ import { type Dispatch, type SetStateAction, useEffect, useState } from "react";
 
 import type { SmdaFieldSearchResult, SmdaFieldUuid } from "#client";
 import { smdaPostFieldOptions } from "#client/@tanstack/react-query.gen";
+import { ConfirmCloseDialog } from "#components/common";
 import { CancelButton, GeneralButton } from "#components/form/button";
 import { SearchFieldForm } from "#components/form/form";
 import { EditDialog, PageSectionSpacer, PageText } from "#styles/common";
@@ -106,6 +107,7 @@ export function FieldSearch({
 }) {
   const [searchValue, setSearchValue] = useState("");
   const [selectedFields, setSelectedFields] = useState<Array<string>>([]);
+  const [confirmCloseDialogOpen, setConfirmCloseDialogOpen] = useState(false);
 
   const { data } = useQuery({
     ...smdaPostFieldOptions({ body: { identifier: searchValue } }),
@@ -114,7 +116,33 @@ export function FieldSearch({
 
   function handleClose() {
     setSearchValue("");
+    setSelectedFields([]);
+    setConfirmCloseDialogOpen(false);
     closeDialog();
+  }
+
+  function handleCloseRequest() {
+    // If there are selected fields, ask for confirmation
+    if (selectedFields.length > 0) {
+      setConfirmCloseDialogOpen(true);
+    } else {
+      handleClose();
+    }
+  }
+
+  // Reset confirm dialog when dialog closes
+  useEffect(() => {
+    if (!isOpen) {
+      setConfirmCloseDialogOpen(false);
+    }
+  }, [isOpen]);
+
+  function handleConfirmCloseDecision(confirm: boolean) {
+    if (confirm) {
+      handleClose();
+    } else {
+      setConfirmCloseDialogOpen(false);
+    }
   }
 
   const setStateCallback = (value: string) => {
@@ -122,33 +150,50 @@ export function FieldSearch({
   };
 
   return (
-    <EditDialog open={isOpen} $maxWidth="200em">
-      <Dialog.Header>Field search</Dialog.Header>
+    <>
+      <EditDialog
+        open={isOpen}
+        isDismissable={true}
+        onClose={handleCloseRequest}
+        $maxWidth="200em"
+      >
+        <Dialog.Header>Field search</Dialog.Header>
 
-      <Dialog.CustomContent>
-        <SearchFormContainer>
-          <SearchFieldForm
-            name="identifier"
-            value={searchValue}
-            helperText="Tip: Use * as a wildcard for finding fields that start with the name. Example: OSEBERG*"
-            setStateCallback={setStateCallback}
+        <Dialog.CustomContent>
+          <SearchFormContainer>
+            <SearchFieldForm
+              name="identifier"
+              value={searchValue}
+              helperText="Tip: Use * as a wildcard for finding fields that start with the name. Example: OSEBERG*"
+              setStateCallback={setStateCallback}
+            />
+          </SearchFormContainer>
+
+          <FieldResults data={data} setSelectedFields={setSelectedFields} />
+        </Dialog.CustomContent>
+
+        <Dialog.Actions>
+          <GeneralButton
+            label="Add fields"
+            disabled={selectedFields.length === 0}
+            onClick={() => {
+              addFields(selectedFields);
+              handleClose();
+            }}
           />
-        </SearchFormContainer>
+          <CancelButton onClick={handleCloseRequest} />
+        </Dialog.Actions>
+      </EditDialog>
 
-        <FieldResults data={data} setSelectedFields={setSelectedFields} />
-      </Dialog.CustomContent>
-
-      <Dialog.Actions>
-        <GeneralButton
-          label="Add fields"
-          disabled={selectedFields.length === 0}
-          onClick={() => {
-            addFields(selectedFields);
-            handleClose();
-          }}
-        />
-        <CancelButton onClick={handleClose} />
-      </Dialog.Actions>
-    </EditDialog>
+      <ConfirmCloseDialog
+        isOpen={confirmCloseDialogOpen}
+        handleConfirmCloseDecision={handleConfirmCloseDecision}
+        title="Discard search results"
+        description="You have selected fields that haven't been added to the masterdata yet."
+        question="Do you want to discard the selected fields and close the search dialog?"
+        confirmLabel="Keep editing"
+        cancelLabel="Discard and close"
+      />
+    </>
   );
 }


### PR DESCRIPTION
Resolves #360 

Possible fix to close the field search dialog first then the masterdata field dialog. 

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
