### PR TITLE
ENH: Add link to Documentation

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -12,6 +12,7 @@ import {
   check,
   checkbox,
   comment,
+  external_link,
   warning_filled,
 } from "@equinor/eds-icons";
 import { tokens } from "@equinor/eds-tokens";
@@ -279,7 +280,19 @@ export function Header() {
         </TopBar.Header>
         <TopBar.Actions>
           <TaskIndicator />
+
           <FeedbackDialog />
+
+          <HeaderActionButton
+            variant="ghost"
+            forwardedAs="a"
+            href="https://equinor.github.io/fmu-settings/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Documentation <Icon data={external_link} size={18} />
+          </HeaderActionButton>
+
           <ProjectInfo />
         </TopBar.Actions>
       </TopBar>


### PR DESCRIPTION
Resolves #383 

Added link to FMU Settings documentation to Header

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
