### PR TITLE
BUG: Use form.subscribe to set submit button disable

### DIFF
--- a/frontend/src/components/form/field.tsx
+++ b/frontend/src/components/form/field.tsx
@@ -11,12 +11,7 @@ import {
   info_circle,
   remove,
 } from "@equinor/eds-icons";
-import {
-  type ChangeEvent,
-  type Dispatch,
-  type SetStateAction,
-  useEffect,
-} from "react";
+import type { ChangeEvent } from "react";
 import type z from "zod";
 
 import { useFieldContext } from "#utils/form";
@@ -53,7 +48,6 @@ export function TextField({
   helperText,
   isReadOnly,
   toUpperCase,
-  setSubmitDisabled,
 }: {
   label: string;
   multiline?: boolean;
@@ -63,21 +57,8 @@ export function TextField({
   helperText?: string;
   isReadOnly?: boolean;
   toUpperCase?: boolean;
-  setSubmitDisabled?: Dispatch<SetStateAction<boolean>>;
 }) {
   const field = useFieldContext<string>();
-
-  useEffect(() => {
-    if (setSubmitDisabled) {
-      setSubmitDisabled(
-        field.state.meta.isDefaultValue || !field.state.meta.isValid,
-      );
-    }
-  }, [
-    setSubmitDisabled,
-    field.state.meta.isDefaultValue,
-    field.state.meta.isValid,
-  ]);
 
   return (
     <InputWrapper helperProps={{ text: helperText }}>

--- a/frontend/src/components/form/form.tsx
+++ b/frontend/src/components/form/form.tsx
@@ -121,11 +121,13 @@ export function EditableTextFieldForm({
             />
           ) : (
             <>
-              <form.Subscribe>
-                {(state) => (
+              <form.Subscribe
+                selector={(state) => [state.isDefaultValue, state.canSubmit]}
+              >
+                {([isDefaultValue, canSubmit]) => (
                   <form.SubmitButton
                     label="Save"
-                    disabled={state.isDefaultValue || !state.canSubmit}
+                    disabled={isDefaultValue || !canSubmit}
                     isPending={mutationIsPending}
                     helperTextDisabled="Value can be submitted when it has been changed and is valid"
                   />

--- a/frontend/src/components/form/form.tsx
+++ b/frontend/src/components/form/form.tsx
@@ -59,7 +59,6 @@ export function EditableTextFieldForm({
   mutationIsPending,
 }: EditableTextFieldFormProps) {
   const [isReadonly, setIsReadonly] = useState(true);
-  const [submitDisabled, setSubmitDisabled] = useState(true);
 
   const validator = handleValidator({ length, minLength, initialValue: value });
 
@@ -108,7 +107,6 @@ export function EditableTextFieldForm({
               placeholder={placeholder}
               helperText={helperText}
               isReadOnly={isReadonly}
-              setSubmitDisabled={setSubmitDisabled}
             />
           )}
         </form.AppField>
@@ -123,12 +121,16 @@ export function EditableTextFieldForm({
             />
           ) : (
             <>
-              <form.SubmitButton
-                label="Save"
-                disabled={submitDisabled}
-                isPending={mutationIsPending}
-                helperTextDisabled="Value can be submitted when it has been changed and is valid"
-              />
+              <form.Subscribe>
+                {(state) => (
+                  <form.SubmitButton
+                    label="Save"
+                    disabled={state.isDefaultValue || !state.canSubmit}
+                    isPending={mutationIsPending}
+                    helperTextDisabled="Value can be submitted when it has been changed and is valid"
+                  />
+                )}
+              </form.Subscribe>
               <form.CancelButton
                 onClick={(e) => {
                   e.preventDefault();

--- a/frontend/src/components/project/overview/ProjectSelector.tsx
+++ b/frontend/src/components/project/overview/ProjectSelector.tsx
@@ -73,7 +73,6 @@ function ProjectSelectorForm({
   isDialogOpen: boolean;
 }) {
   const [initConfirmDialogOpen, setInitConfirmDialogOpen] = useState(false);
-  const [submitDisabled, setSubmitDisabled] = useState(true);
   const [helperTextRecentProjects, sethelperTextRecentProjects] = useState("");
   const [helperTextProjectPath, setHelperTextProjectPath] = useState("");
   const [valueSource, setValueSource] = useState<ValueSource>("");
@@ -255,10 +254,7 @@ function ProjectSelectorForm({
                   icon: <Icon data={error_filled} size={16} />,
                 }}
               >
-                <field.TextField
-                  label="Alternatively, enter a path to the project"
-                  setSubmitDisabled={setSubmitDisabled}
-                />
+                <field.TextField label="Alternatively, enter a path to the project" />
               </InputWrapper>
             )}
           </form.AppField>
@@ -276,12 +272,16 @@ function ProjectSelectorForm({
 
         <Dialog.Actions>
           <form.AppForm>
-            <form.SubmitButton
-              label="Select"
-              disabled={submitDisabled}
-              isPending={isPending}
-              helperTextDisabled="Select a recent project or enter a valid project path"
-            />
+            <form.Subscribe>
+              {(state) => (
+                <form.SubmitButton
+                  label="Select"
+                  disabled={state.isDefaultValue || !state.canSubmit}
+                  isPending={isPending}
+                  helperTextDisabled="Select a recent project or enter a valid project path"
+                />
+              )}
+            </form.Subscribe>
             <form.CancelButton
               onClick={() => {
                 closeProjectSelector({ formReset: form.reset });


### PR DESCRIPTION
Resolves #83 

Use form.subscribe to set submit button disable

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
