### PR TITLE
DEV: Set Dependabot to Ignore major version updates to EDS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,9 @@ updates:
       interval: "weekly"
     allow:
       - dependency-type: "all"
+    ignore:
+      - dependency-name: "@equinor/eds-*"
+      - update-types: ["version-update:semver-major"]
     groups:
       all-deps:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,7 +28,7 @@ updates:
       - dependency-type: "all"
     ignore:
       - dependency-name: "@equinor/eds-*"
-      - update-types: ["version-update:semver-major"]
+        update-types: ["version-update:semver-major"]
     groups:
       all-deps:
         patterns:


### PR DESCRIPTION
Resolves #401

Configures Dependabot to ignore major version updates to EDS (Equinor Design System), and thus not create PRs with such update proposals.

## Checklist

- [ ] Tests added - not relevant
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [X] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
