### PR TITLE
ENH: Unautomate red error toasts

### DIFF
--- a/frontend/src/components/LockStatus.tsx
+++ b/frontend/src/components/LockStatus.tsx
@@ -39,6 +39,7 @@ function EnableEditingButton({ lockStatus }: { lockStatus?: LockStatus }) {
                 toast.error(
                   "An error occured and project remains read-only. " +
                     (lockStatus?.last_lock_acquire_error ?? ""),
+                  { autoClose: false },
                 );
               }
             },

--- a/frontend/src/components/project/masterdata/Edit.tsx
+++ b/frontend/src/components/project/masterdata/Edit.tsx
@@ -339,7 +339,7 @@ export function Edit({
       if (error.response?.status === HTTP_STATUS_UNPROCESSABLE_CONTENT) {
         const message = httpValidationErrorToString(error);
         console.error(message);
-        toast.error(message);
+        toast.error(message, { autoClose: false });
       }
     },
     meta: {

--- a/frontend/src/components/project/overview/Access.tsx
+++ b/frontend/src/components/project/overview/Access.tsx
@@ -112,7 +112,7 @@ function AccessEditorForm({
       if (error.response?.status === HTTP_STATUS_UNPROCESSABLE_CONTENT) {
         const message = httpValidationErrorToString(error);
         console.error(message);
-        toast.error(message);
+        toast.error(message, { autoClose: false });
       }
     },
     meta: {

--- a/frontend/src/components/project/overview/Model.tsx
+++ b/frontend/src/components/project/overview/Model.tsx
@@ -71,7 +71,7 @@ function ModelEditorForm({
       if (error.response?.status === HTTP_STATUS_UNPROCESSABLE_CONTENT) {
         const message = httpValidationErrorToString(error);
         console.error(message);
-        toast.error(message);
+        toast.error(message, { autoClose: false });
       }
     },
     meta: {

--- a/frontend/src/components/project/rms/Overview.tsx
+++ b/frontend/src/components/project/rms/Overview.tsx
@@ -93,7 +93,7 @@ function RmsEditorForm({
       if (error.response?.status === HTTP_STATUS_UNPROCESSABLE_CONTENT) {
         const message = httpValidationErrorToString(error);
         console.error(message);
-        toast.error(message);
+        toast.error(message, { autoClose: false });
       }
     },
     meta: {
@@ -272,7 +272,7 @@ function RmsProjectActions({
       if (error.response?.status === HTTP_STATUS_UNPROCESSABLE_CONTENT) {
         const message = (error.response.data as { detail?: string }).detail;
         console.error(message);
-        toast.error(message);
+        toast.error(message, { autoClose: false });
       }
     },
     meta: {

--- a/frontend/src/components/project/rms/Stratigraphy.tsx
+++ b/frontend/src/components/project/rms/Stratigraphy.tsx
@@ -321,7 +321,7 @@ function Edit({
       if (error.response?.status === HTTP_STATUS_UNPROCESSABLE_CONTENT) {
         const message = httpValidationErrorToString(error);
         console.error(message);
-        toast.error(message);
+        toast.error(message, { autoClose: false });
       }
     },
     meta: {

--- a/frontend/src/components/project/stratigraphy/Overview.tsx
+++ b/frontend/src/components/project/stratigraphy/Overview.tsx
@@ -432,7 +432,7 @@ function Elements({
       if (error.response?.status === HTTP_STATUS_UNPROCESSABLE_CONTENT) {
         const message = httpValidationErrorToString(error);
         console.error(message);
-        toast.error(message);
+        toast.error(message, { autoClose: false });
       }
     },
     meta: {

--- a/frontend/src/utils/authentication.ts
+++ b/frontend/src/utils/authentication.ts
@@ -117,7 +117,7 @@ export function handleSsoLogin(msalInstance: IPublicClientApplication) {
     void msalInstance.loginRedirect({ scopes: ssoScopes });
   } catch (error) {
     console.error("Error when logging in to SSO: ", error);
-    toast.error(String(error));
+    toast.error(String(error), { autoClose: false });
   }
 }
 

--- a/frontend/src/utils/query.ts
+++ b/frontend/src/utils/query.ts
@@ -28,7 +28,7 @@ export const defaultErrorHandling = (error: Error, errorPrefix: string) => {
         String(error.response.data.detail)
       : error.message);
   console.error(message);
-  toast.error(message);
+  toast.error(message, { autoClose: false });
 };
 
 export const mutationRetry = (failureCount: number, error: Error) => {


### PR DESCRIPTION
Resolves #397 

User feedback : Unautomate red error toasts so that the user can decide themselves to close them. 

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
