### PR TITLE
ENH: Set specific styling for unmappable and not-set stratigraphic mappings

### DIFF
--- a/frontend/src/components/project/stratigraphy/Overview.style.ts
+++ b/frontend/src/components/project/stratigraphy/Overview.style.ts
@@ -1,11 +1,41 @@
 import { tokens } from "@equinor/eds-tokens";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
 import type {
   HorizonLineStyle,
   ZonePlacementInfo,
 } from "../stratigraphicFramework/types";
 import type { ElementType } from "./types";
+
+function getColors(
+  isTargetSystem: boolean,
+  isUnmappable: boolean,
+  isMissingValue: boolean,
+) {
+  let backgroundColor = "inherit";
+  let color = "inherit";
+
+  if (isTargetSystem) {
+    if (isUnmappable) {
+      backgroundColor = tokens.colors.infographic.substitute__pink_salmon.hex;
+      color = tokens.colors.text.static_icons__default.hex;
+    } else if (isMissingValue) {
+      backgroundColor = "transparent";
+      color = tokens.colors.text.static_icons__tertiary.hex;
+    } else {
+      backgroundColor = tokens.colors.infographic.substitute__blue_overcast.hex;
+      color = tokens.colors.text.static_icons__primary_white.hex;
+    }
+  } else {
+    backgroundColor = tokens.colors.infographic.primary__mist_blue.hex;
+    color = tokens.colors.text.static_icons__default.hex;
+  }
+
+  return css`
+		background-color: ${backgroundColor};
+		color: ${color};
+	`;
+}
 
 export const HorizonItem = styled.div<{
   $rowStart: number;
@@ -69,26 +99,30 @@ export const ElementSystem = styled.div`
 `;
 
 export const ElementInfo = styled.div.attrs<{
-  $targetSystem?: boolean;
+  $isTargetSystem?: boolean;
 }>((props) => ({
-  $targetSystem: props.$targetSystem ?? false,
+  $isTargetSystem: props.$isTargetSystem ?? false,
 }))`
-	justify-self: ${({ $targetSystem }) => ($targetSystem ? "right" : undefined)};
+	justify-self: ${({ $isTargetSystem }) => ($isTargetSystem ? "right" : undefined)};
 
 	cursor: default;
 `;
 
 export const ElementSystemName = styled.div.attrs<{
   $elementType?: ElementType;
-}>((props) => ({ $elementType: props.$elementType }))`
+  $isMissingvalue?: boolean;
+}>((props) => ({
+  $elementType: props.$elementType,
+  $isMissingvalue: Boolean(props.$isMissingvalue),
+}))`
 	width: fit-content;
 	padding: 0 ${tokens.spacings.comfortable.small} 0 ${tokens.spacings.comfortable.small};
-	padding-top: ${(props) => (props.$elementType === "horizon" ? "1px" : undefined)};
-	border: ${(props) => (props.$elementType === "horizon" ? "solid 1px #cccccc" : undefined)};
-	border-bottom: none;
+	padding-top: ${({ $elementType }) => ($elementType === "horizon" ? "1px" : undefined)};
+	border: ${({ $elementType }) => ($elementType === "horizon" ? "solid 1px #cccccc" : undefined)};
+	border-bottom: ${({ $isMissingvalue }) => ($isMissingvalue ? undefined : "none")};
 	border-radius: ${tokens.shape.corners.borderRadius};
-	border-bottom-left-radius: 0%;
-	border-bottom-right-radius: 0%;
+	border-bottom-left-radius: ${({ $isMissingvalue }) => ($isMissingvalue ? undefined : "0%")};
+	border-bottom-right-radius: ${({ $isMissingvalue }) => ($isMissingvalue ? undefined : "0%")};
 	background: #ffffff;
 
 	color: black;
@@ -97,33 +131,35 @@ export const ElementSystemName = styled.div.attrs<{
 `;
 
 export const ElementName = styled.div.attrs<{
-  $targetSystem?: boolean;
-  $missingvalue?: boolean;
+  $isTargetSystem?: boolean;
+  $isUnmappable?: boolean;
+  $isMissingvalue?: boolean;
 }>((props) => ({
-  $targetSystem: props.$targetSystem ?? false,
-  $missingvalue: props.$missingvalue ?? false,
+  $isTargetSystem: Boolean(props.$isTargetSystem),
+  $isUnmappable: Boolean(props.$isUnmappable),
+  $isMissingvalue: Boolean(props.$isMissingvalue),
 }))`
 	width: fit-content;
 	padding: ${tokens.spacings.comfortable.x_small} ${tokens.spacings.comfortable.small};
+	padding-left: ${({ $isMissingvalue }) => ($isMissingvalue ? "0" : undefined)};
 	border-radius: ${tokens.shape.corners.borderRadius};
 	border-top-left-radius: 0%;
-	background: ${(props) =>
-    props.$targetSystem
-      ? tokens.colors.infographic.substitute__blue_overcast.hex
-      : tokens.colors.infographic.primary__mist_blue.hex};
 
 	display: flex;
 	gap: ${tokens.spacings.comfortable.small};
 
-	color: ${(props) =>
-    props.$targetSystem
-      ? tokens.colors.text.static_icons__primary_white.hex
-      : tokens.colors.text.static_icons__default.hex};
 	font-size: ${tokens.typography.navigation.button.fontSize};
 	font-weight: ${tokens.typography.navigation.button.fontWeight};
-	font-style: ${(props) => (props.$missingvalue ? "italic" : "normal")};
+	font-style: ${({ $isUnmappable, $isMissingvalue }) => ($isUnmappable || $isMissingvalue ? "italic" : "normal")};
 	line-height: ${tokens.typography.navigation.button.lineHeight};
 	white-space: nowrap;
+
+	${({ $isTargetSystem, $isUnmappable, $isMissingvalue }) =>
+    getColors(
+      Boolean($isTargetSystem),
+      Boolean($isUnmappable),
+      Boolean($isMissingvalue),
+    )}
 
 	.aliases {
 		color: ${tokens.colors.infographic.substitute__purple_berry.hex}

--- a/frontend/src/components/project/stratigraphy/Overview.tsx
+++ b/frontend/src/components/project/stratigraphy/Overview.tsx
@@ -310,6 +310,8 @@ function Element({
   canEdit: boolean;
   editClick: (elementMapping: ElementMapping) => void;
 }) {
+  const isMissingValue =
+    elementMapping.smdaName === "" && !elementMapping.unmappable;
   const aliasCount = elementMapping.aliases.length;
 
   return (
@@ -335,15 +337,17 @@ function Element({
         </ElementSystem>
 
         <ElementSystem>
-          <ElementInfo $targetSystem={true}>
-            <ElementSystemName $elementType={elementMapping.elementType}>
+          <ElementInfo $isTargetSystem={true}>
+            <ElementSystemName
+              $elementType={elementMapping.elementType}
+              $isMissingvalue={isMissingValue}
+            >
               SMDA
             </ElementSystemName>
             <ElementName
-              $targetSystem={true}
-              $missingvalue={
-                elementMapping.smdaName === "" || elementMapping.unmappable
-              }
+              $isTargetSystem={true}
+              $isUnmappable={elementMapping.unmappable}
+              $isMissingvalue={isMissingValue}
             >
               {elementMapping.smdaName !== ""
                 ? elementMapping.smdaName


### PR DESCRIPTION
Resolves #382
Resolves #396

Sets specific styling for mappings which are unmappable and mappings which are not set.

- An unmappable mapping has a red-ish background colour, indicating something which doesn't exist. The text "No horizon"/"No zone" is in italics, indicating that it is not an actual name of an element. As the background colour is light, the text color is dark
- A not-set mapping does not show a visible box. The system name ("SMDA") is shown, indicating the name of the system where the mapping has to be set. For future mapping implementations (such as wellbores) there might be more than one system to map to, so the presence of the system name for not-set mappings is needed. The text shown is "(not set)", which is the same text used elsewhere in the application to indicate values that are not set. The font style is in italics to indicate that the text is not an actual name of an element

<img width="906" height="550" alt="Skjermbilde 2026-06-01 kl  15 35 25" src="https://github.com/user-attachments/assets/d6dfcab6-46e4-4943-bfff-1dbcb73e32b0" />

Issue #382 has a comment about using colours from SMDA for mappings that are set. If implemented, such colours would probably not have been used as the main background colour of an SMDA name box, as it is more important to consistently use the same background colour (blue) for all mapped names. Rather, the SMDA colour could have been added to the SMDA name box, possibly as a stripe at the bottom. However, the SMDA colours would have needed to be stored as part of the mapping data in the FMU project, so as to be available also when the user does not have SMDA access. Storing of such additional information is not currently provided for the mappings data, so usage of such colour data is not implemented here.


## Checklist

- [ ] Tests added - not relevant
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
