### PR TITLE
ENH: Enable using full width for stratigraphic framework

### DIFF
--- a/frontend/src/components/project/rms/Overview.tsx
+++ b/frontend/src/components/project/rms/Overview.tsx
@@ -27,6 +27,7 @@ import {
   InfoBox,
   PageCode,
   PageSectionSpacer,
+  PageSectionWidthConstrained,
   PageText,
 } from "#styles/common";
 import {
@@ -389,25 +390,27 @@ export function Overview({
 
   return (
     <>
-      <PageText>
-        The following is the main RMS project located in the <i>rms/model</i>{" "}
-        directory. The version is detected automatically:
-      </PageText>
+      <PageSectionWidthConstrained>
+        <PageText>
+          The following is the main RMS project located in the <i>rms/model</i>{" "}
+          directory. The version is detected automatically:
+        </PageText>
 
-      {rmsData ? (
-        <RmsInfo rmsData={rmsData} />
-      ) : (
-        <PageCode>No RMS project information found in the project.</PageCode>
-      )}
+        {rmsData ? (
+          <RmsInfo rmsData={rmsData} />
+        ) : (
+          <PageCode>No RMS project information found in the project.</PageCode>
+        )}
 
-      <RmsProjectActions
-        rmsData={rmsData}
-        projectReadOnly={projectReadOnly}
-        setIsRmsProjectOpen={setIsRmsProjectOpen}
-        isRmsProjectOpen={isRmsProjectOpen}
-      />
+        <RmsProjectActions
+          rmsData={rmsData}
+          projectReadOnly={projectReadOnly}
+          setIsRmsProjectOpen={setIsRmsProjectOpen}
+          isRmsProjectOpen={isRmsProjectOpen}
+        />
 
-      <PageSectionSpacer />
+        <PageSectionSpacer />
+      </PageSectionWidthConstrained>
 
       <Stratigraphy
         rmsData={rmsData}

--- a/frontend/src/components/project/rms/Stratigraphy.tsx
+++ b/frontend/src/components/project/rms/Stratigraphy.tsx
@@ -31,6 +31,7 @@ import {
   GenericDialog,
   PageCode,
   PageHeader,
+  PageSectionWidthConstrained,
   PageText,
 } from "#styles/common";
 import {
@@ -470,42 +471,49 @@ export function Stratigraphy({
 
   return (
     <>
-      <PageHeader $variant="h3">Stratigraphy</PageHeader>
+      <PageSectionWidthConstrained>
+        <PageHeader $variant="h3">Stratigraphy</PageHeader>
 
-      <PageText>
-        The following is the model stratigraphy stored in the project, this can
-        be a subset or the full RMS stratigraphy. It is only the stored
-        stratigraphy that will be possible to map to official stratigraphic
-        names.
-      </PageText>
+        <PageText>
+          The following is the model stratigraphy stored in the project, this
+          can be a subset or the full RMS stratigraphy. It is only the stored
+          stratigraphy that will be possible to map to official stratigraphic
+          names.
+        </PageText>
+      </PageSectionWidthConstrained>
 
       {projectHorizons.length ? (
         <StratigraphicFramework
           horizons={projectHorizons}
           zones={projectZones}
           disablePointerEvents={false}
+          enableWidthExpansion={true}
         >
           <Horizons />
           <Zones />
         </StratigraphicFramework>
       ) : (
-        <PageCode>
-          No stratigraphy information currently stored in the project.
-        </PageCode>
+        <PageSectionWidthConstrained>
+          <PageCode>
+            No stratigraphy information currently stored in the project.
+          </PageCode>
+        </PageSectionWidthConstrained>
       )}
 
-      <GeneralButton
-        label={projectHorizons.length ? "Edit" : "Add"}
-        disabled={projectReadOnly || !isRmsProjectOpen}
-        tooltipText={
-          projectReadOnly
-            ? "Project is read-only"
-            : !isRmsProjectOpen
-              ? "RMS project is not open"
-              : undefined
-        }
-        onClick={openDialog}
-      />
+      <PageSectionWidthConstrained>
+        <GeneralButton
+          label={projectHorizons.length ? "Edit" : "Add"}
+          disabled={projectReadOnly || !isRmsProjectOpen}
+          tooltipText={
+            projectReadOnly
+              ? "Project is read-only"
+              : !isRmsProjectOpen
+                ? "RMS project is not open"
+                : undefined
+          }
+          onClick={openDialog}
+        />
+      </PageSectionWidthConstrained>
 
       <Edit
         projectHorizons={projectHorizons}

--- a/frontend/src/components/project/stratigraphicFramework/StratigraphicFramework.style.ts
+++ b/frontend/src/components/project/stratigraphicFramework/StratigraphicFramework.style.ts
@@ -29,9 +29,17 @@ export const StratigraphicFrameworkHeader = styled.div.attrs<{
   div {
     padding: ${tokens.spacings.comfortable.x_small} ${tokens.spacings.comfortable.small};
 
-    &:nth-child(2) {    
+    &:nth-child(2) {
       display: flex;
       justify-content: center;
+      grid-row: 1;
+      grid-column: 2 / -1;
+    }
+
+    &:nth-child(3) {
+      display: flex;
+      justify-content: right;
+      grid-row: 1;
       grid-column: 2 / -1;
     }
   }

--- a/frontend/src/components/project/stratigraphicFramework/StratigraphicFramework.style.ts
+++ b/frontend/src/components/project/stratigraphicFramework/StratigraphicFramework.style.ts
@@ -22,6 +22,8 @@ export const StratigraphicFrameworkHeader = styled.div.attrs<{
     gridTemplateColumns: `minmax(max-content, 2fr) repeat(${$numStratColumns}, 3fr)`,
   },
 }))`
+  padding-bottom: ${tokens.spacings.comfortable.small};
+
   display: grid;
   font-weight: ${tokens.typography.table.cell_header.fontWeight};
   font-size: ${tokens.typography.table.cell_text.fontSize};
@@ -41,6 +43,10 @@ export const StratigraphicFrameworkHeader = styled.div.attrs<{
       justify-content: right;
       grid-row: 1;
       grid-column: 2 / -1;
+
+      position: relative;
+      top: -8px;
+      height: 16px;
     }
   }
 `;

--- a/frontend/src/components/project/stratigraphicFramework/StratigraphicFramework.style.ts
+++ b/frontend/src/components/project/stratigraphicFramework/StratigraphicFramework.style.ts
@@ -32,21 +32,22 @@ export const StratigraphicFrameworkHeader = styled.div.attrs<{
     padding: ${tokens.spacings.comfortable.x_small} ${tokens.spacings.comfortable.small};
 
     &:nth-child(2) {
-      display: flex;
-      justify-content: center;
       grid-row: 1;
       grid-column: 2 / -1;
+
+      display: flex;
+      justify-content: center;
     }
 
     &:nth-child(3) {
-      display: flex;
-      justify-content: right;
       grid-row: 1;
       grid-column: 2 / -1;
-
-      position: relative;
-      top: -8px;
       height: 16px;
+
+      display: flex;
+      justify-content: right;
+      align-items: center;
+
     }
   }
 `;

--- a/frontend/src/components/project/stratigraphicFramework/StratigraphicFramework.tsx
+++ b/frontend/src/components/project/stratigraphicFramework/StratigraphicFramework.tsx
@@ -1,4 +1,4 @@
-import { Icon } from "@equinor/eds-core-react";
+import { Button, EdsProvider, Icon } from "@equinor/eds-core-react";
 import { collapse, expand } from "@equinor/eds-icons";
 import { useLocation } from "@tanstack/react-router";
 import type React from "react";
@@ -121,16 +121,22 @@ export function StratigraphicFramework({
           <div>Zones</div>
           {enableWidthExpansion && (
             <div>
-              <Icon
-                data={notWidthConstrained ? collapse : expand}
-                title={
-                  notWidthConstrained
-                    ? "Expand to full width"
-                    : "Collapse width"
-                }
-                size={16}
-                onClick={toggleNotWidthConstraint}
-              />
+              <EdsProvider density="compact">
+                <Button
+                  variant="ghost_icon"
+                  title={
+                    notWidthConstrained
+                      ? "Collapse width"
+                      : "Expand to full width"
+                  }
+                  onClick={toggleNotWidthConstraint}
+                >
+                  <Icon
+                    data={notWidthConstrained ? collapse : expand}
+                    size={16}
+                  />
+                </Button>
+              </EdsProvider>
             </div>
           )}
         </StratigraphicFrameworkHeader>

--- a/frontend/src/components/project/stratigraphicFramework/StratigraphicFramework.tsx
+++ b/frontend/src/components/project/stratigraphicFramework/StratigraphicFramework.tsx
@@ -1,7 +1,16 @@
+import { Icon } from "@equinor/eds-core-react";
+import { collapse, expand } from "@equinor/eds-icons";
+import { useLocation } from "@tanstack/react-router";
 import type React from "react";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
 import type { RmsHorizon, RmsStratigraphicZone } from "#client";
+import { PageSectionWidthConstrained } from "#styles/common";
+import {
+  getStorageItem,
+  STORAGENAME_PAGESECTION_NOTWIDTHCONSTRAINED_BASE,
+  setStorageItem,
+} from "#utils/storage";
 import { FrameworkDataContext } from "./FrameworkData";
 import { getHorizonLineStyle, getZoneGridPlacement } from "./functions";
 import {
@@ -22,6 +31,7 @@ export function StratigraphicFramework({
   onHorizonClick,
   maxHeight,
   disablePointerEvents = false,
+  enableWidthExpansion = false,
   children: [horizonsComponent, zonesComponent],
 }: {
   horizons: RmsHorizon[];
@@ -34,8 +44,23 @@ export function StratigraphicFramework({
   onHorizonClick?: (horizon: RmsHorizon, isUnselected: boolean) => void;
   maxHeight?: string;
   disablePointerEvents?: boolean;
+  enableWidthExpansion?: boolean;
   children: React.ReactNode[];
 }) {
+  const locationPathname = useLocation({
+    select: (location) => location.pathname,
+  });
+  const storageKeyWidthConstraint = [
+    STORAGENAME_PAGESECTION_NOTWIDTHCONSTRAINED_BASE,
+    "stratigraphicFramework",
+    locationPathname,
+  ].join("-");
+
+  const [notWidthConstrained, setNotWidthConstrained] = useState(
+    enableWidthExpansion &&
+      getStorageItem(sessionStorage, storageKeyWidthConstraint, "boolean"),
+  );
+
   const frameworkData = useMemo(() => {
     const zoneGridPlacement = getZoneGridPlacement(zones, horizons);
     const unselectedZoneNamesSet = new Set(unselectedZoneNames);
@@ -71,35 +96,63 @@ export function StratigraphicFramework({
     onZoneClick,
   ]);
 
+  function toggleNotWidthConstraint() {
+    setNotWidthConstrained((notWidthConstrained) => {
+      setStorageItem(
+        sessionStorage,
+        storageKeyWidthConstraint,
+        !notWidthConstrained,
+      );
+
+      return !notWidthConstrained;
+    });
+  }
+
   return (
-    <StratigraphicFrameworkContainer
-      $maxHeight={maxHeight}
-      $disablePointerEvents={disablePointerEvents}
-    >
-      <StratigraphicFrameworkHeader
-        $numStratColumns={frameworkData.numStratColumns}
+    <PageSectionWidthConstrained $notConstrained={notWidthConstrained}>
+      <StratigraphicFrameworkContainer
+        $maxHeight={maxHeight}
+        $disablePointerEvents={disablePointerEvents}
       >
-        <div>Horizons</div>
-        <div>Zones</div>
-      </StratigraphicFrameworkHeader>
+        <StratigraphicFrameworkHeader
+          $numStratColumns={frameworkData.numStratColumns}
+        >
+          <div>Horizons</div>
+          <div>Zones</div>
+          {enableWidthExpansion && (
+            <div>
+              <Icon
+                data={notWidthConstrained ? collapse : expand}
+                title={
+                  notWidthConstrained
+                    ? "Expand to full width"
+                    : "Collapse width"
+                }
+                size={16}
+                onClick={toggleNotWidthConstraint}
+              />
+            </div>
+          )}
+        </StratigraphicFrameworkHeader>
 
-      <StratigraphicFrameworkContent
-        $numStratColumns={frameworkData.numStratColumns}
-      >
-        <FrameworkDataContext value={frameworkData}>
-          {horizons.map((horizon, idx) => (
-            <GridLine
-              key={horizon.name}
-              $rowStart={(idx + 1) * 3 - 1}
-              $lineStyle={getHorizonLineStyle(horizon)}
-            ></GridLine>
-          ))}
+        <StratigraphicFrameworkContent
+          $numStratColumns={frameworkData.numStratColumns}
+        >
+          <FrameworkDataContext value={frameworkData}>
+            {horizons.map((horizon, idx) => (
+              <GridLine
+                key={horizon.name}
+                $rowStart={(idx + 1) * 3 - 1}
+                $lineStyle={getHorizonLineStyle(horizon)}
+              ></GridLine>
+            ))}
 
-          {horizonsComponent}
+            {horizonsComponent}
 
-          {zonesComponent}
-        </FrameworkDataContext>
-      </StratigraphicFrameworkContent>
-    </StratigraphicFrameworkContainer>
+            {zonesComponent}
+          </FrameworkDataContext>
+        </StratigraphicFrameworkContent>
+      </StratigraphicFrameworkContainer>
+    </PageSectionWidthConstrained>
   );
 }

--- a/frontend/src/components/project/stratigraphy/Overview.tsx
+++ b/frontend/src/components/project/stratigraphy/Overview.tsx
@@ -42,6 +42,7 @@ import { mappingsPaths } from "#services/project";
 import {
   EditDialog,
   PageSectionSpacer,
+  PageSectionWidthConstrained,
   PageText,
   WarningBox,
 } from "#styles/common";
@@ -646,10 +647,12 @@ export function Overview({
 
   return (
     <>
-      <PageText>
-        The following are the mappings for horizons and zones, showing the names
-        in RMS and SMDA.
-      </PageText>
+      <PageSectionWidthConstrained>
+        <PageText>
+          The following are the mappings for horizons and zones, showing the
+          names in RMS and SMDA.
+        </PageText>
+      </PageSectionWidthConstrained>
 
       {rmsProject.horizons !== undefined &&
       rmsProject.horizons !== null &&
@@ -659,6 +662,7 @@ export function Overview({
           <StratigraphicFramework
             horizons={rmsProject.horizons}
             zones={rmsProject.zones}
+            enableWidthExpansion={true}
           >
             <Elements
               elementType="horizon"
@@ -678,26 +682,29 @@ export function Overview({
             />
           </StratigraphicFramework>
 
-          {editMode &&
-            !projectReadOnly &&
-            smdaHealthStatus &&
-            (stratigraphicColumn ? (
-              <PageText>
-                💡 Set SMDA names for zones first. Horizon options are derived
-                from the top and base horizons of mapped zones.
-              </PageText>
-            ) : (
-              <WarningBox>
-                <PageText $marginBottom="0">
-                  No stratigraphic column is set in the masterdata.{" "}
-                  <Link to="/project/masterdata">Set this value</Link> to enable
-                  editing of stratigraphy mappings.
+          {editMode && !projectReadOnly && smdaHealthStatus && (
+            <PageSectionWidthConstrained>
+              {stratigraphicColumn ? (
+                <PageText>
+                  💡 Set SMDA names for zones first. Horizon options are derived
+                  from the top and base horizons of mapped zones.
                 </PageText>
-              </WarningBox>
-            ))}
+              ) : (
+                <WarningBox>
+                  <PageText $marginBottom="0">
+                    No stratigraphic column is set in the masterdata.{" "}
+                    <Link to="/project/masterdata">Set this value</Link> to
+                    enable editing of stratigraphy mappings.
+                  </PageText>
+                </WarningBox>
+              )}
+            </PageSectionWidthConstrained>
+          )}
         </>
       ) : (
-        <PageText>No horizons exist.</PageText>
+        <PageSectionWidthConstrained>
+          <PageText>No horizons exist.</PageText>
+        </PageSectionWidthConstrained>
       )}
     </>
   );

--- a/frontend/src/routes/project/rms.tsx
+++ b/frontend/src/routes/project/rms.tsx
@@ -4,7 +4,12 @@ import { Suspense } from "react";
 import { Loading } from "#components/common";
 import { Overview } from "#components/project/rms/Overview";
 import { useProject } from "#services/project";
-import { PageHeader, PageText } from "#styles/common";
+import {
+  PageContainerNotWidthConstrained,
+  PageHeader,
+  PageSectionWidthConstrained,
+  PageText,
+} from "#styles/common";
 
 export const Route = createFileRoute("/project/rms")({
   component: RouteComponent,
@@ -19,18 +24,22 @@ function Content() {
       projectReadOnly={!(project.lockStatus?.is_lock_acquired ?? false)}
     />
   ) : (
-    <PageText>Project not set.</PageText>
+    <PageSectionWidthConstrained>
+      <PageText>Project not set.</PageText>
+    </PageSectionWidthConstrained>
   );
 }
 
 function RouteComponent() {
   return (
-    <>
-      <PageHeader>RMS</PageHeader>
+    <PageContainerNotWidthConstrained>
+      <PageSectionWidthConstrained>
+        <PageHeader>RMS</PageHeader>
+      </PageSectionWidthConstrained>
 
       <Suspense fallback={<Loading />}>
         <Content />
       </Suspense>
-    </>
+    </PageContainerNotWidthConstrained>
   );
 }

--- a/frontend/src/routes/project/stratigraphy.tsx
+++ b/frontend/src/routes/project/stratigraphy.tsx
@@ -6,7 +6,12 @@ import { Loading, SmdaHealthCheckInfo } from "#components/common";
 import { Overview } from "#components/project/stratigraphy/Overview";
 import { useProject } from "#services/project";
 import { useSmdaHealthCheck } from "#services/smda";
-import { PageHeader, PageText } from "#styles/common";
+import {
+  PageContainerNotWidthConstrained,
+  PageHeader,
+  PageSectionWidthConstrained,
+  PageText,
+} from "#styles/common";
 import {
   getStorageItem,
   STORAGENAME_STRATIGRAPHY_EDIT_MODE,
@@ -43,7 +48,11 @@ function Content() {
   }
 
   if (!project.status) {
-    return <PageText>Project not set.</PageText>;
+    return (
+      <PageSectionWidthConstrained>
+        <PageText>Project not set.</PageText>
+      </PageSectionWidthConstrained>
+    );
   }
 
   return (
@@ -61,24 +70,30 @@ function Content() {
             editMode={editMode}
           />
 
-          {editMode ? (
-            <SmdaHealthCheckInfo
-              feature="editing mappings"
-              healthCheck={healthCheck}
-              setRequestAcquireSsoAccessToken={setRequestAcquireSsoAccessToken}
-            />
-          ) : (
-            <PageText>
-              {" "}
-              💡 To manage mappings,{" "}
-              <Typography onClick={toggleEditMode} link>
-                enable editing mode.
-              </Typography>
-            </PageText>
-          )}
+          <PageSectionWidthConstrained>
+            {editMode ? (
+              <SmdaHealthCheckInfo
+                feature="editing mappings"
+                healthCheck={healthCheck}
+                setRequestAcquireSsoAccessToken={
+                  setRequestAcquireSsoAccessToken
+                }
+              />
+            ) : (
+              <PageText>
+                {" "}
+                💡 To manage mappings,{" "}
+                <Typography onClick={toggleEditMode} link>
+                  enable editing mode.
+                </Typography>
+              </PageText>
+            )}
+          </PageSectionWidthConstrained>
         </>
       ) : (
-        <PageText>No RMS project is selected.</PageText>
+        <PageSectionWidthConstrained>
+          <PageText>No RMS project is selected.</PageText>
+        </PageSectionWidthConstrained>
       )}
     </>
   );
@@ -86,12 +101,14 @@ function Content() {
 
 function RouteComponent() {
   return (
-    <>
-      <PageHeader>Stratigraphy</PageHeader>
+    <PageContainerNotWidthConstrained>
+      <PageSectionWidthConstrained>
+        <PageHeader>Stratigraphy</PageHeader>
+      </PageSectionWidthConstrained>
 
       <Suspense fallback={<Loading />}>
         <Content />
       </Suspense>
-    </>
+    </PageContainerNotWidthConstrained>
   );
 }

--- a/frontend/src/styles/common.ts
+++ b/frontend/src/styles/common.ts
@@ -8,8 +8,23 @@ import {
 import { tokens } from "@equinor/eds-tokens";
 import styled from "styled-components";
 
+const WidthConstraint = "55em";
+const NotWidthConstrainedName = "notWidthConstrained";
+
 export const PageContainer = styled.div`
-  max-width: 55em;
+  &:not(:has(> .${NotWidthConstrainedName})) {
+    max-width: ${WidthConstraint};
+  }
+`;
+
+export const PageContainerNotWidthConstrained = styled.div.attrs({
+  className: NotWidthConstrainedName,
+})``;
+
+export const PageSectionWidthConstrained = styled.div<{
+  $notConstrained?: boolean;
+}>`
+  max-width: ${({ $notConstrained }) => ($notConstrained ? undefined : WidthConstraint)};
 `;
 
 export const PageHeader = styled(Typography).attrs<{

--- a/frontend/src/utils/storage.ts
+++ b/frontend/src/utils/storage.ts
@@ -1,5 +1,7 @@
 export const STORAGENAME_API_TOKEN = "apiToken";
 export const STORAGENAME_MASTERDATA_EDIT_MODE = "masterdataEditMode";
+export const STORAGENAME_PAGESECTION_NOTWIDTHCONSTRAINED_BASE =
+  "pageSectionNotWidthConstrained";
 export const STORAGENAME_RMS_PROJECT_OPEN = "rmsProjectOpen";
 export const STORAGENAME_STRATIGRAPHY_EDIT_MODE = "stratigraphyEditMode";
 


### PR DESCRIPTION
Resolves #387 

Enables using full width for the stratigraphic tables on the RMS and Stratigraphy pages.

There are two parts to this implementation:

### Enabling setting width constraint on sections instead of on the page as a whole

The main layout sets a width constraint on the content part of the page, set to `55em`. This is part of `PageContainer` used in the root route (`routes/__root.tsx`). This is now updated so that if there is a child with the class name `notWidthConstrained` the width constraint will not apply:

```ts
export const PageContainer = styled.div`
  &:not(:has(> .notWidthConstrained)) {
    max-width: 55em;
  }
`;
```

On pages that has sections that will be using full width, the top level content needs to be wrapped in the new `PageContainerNotWidthConstrained` component, which will affect the width constraint rule on the regular `PageContainer` component. Then all sections of the page that will *not* be using full width needs to be wrapped in the new `PageSectionWidthConstrained` component, as this sets the width constraint. This component can wrap multiple sections, ie. `PageHeader`, `PageText` and `PageCode`.

Components that will use full width also need to be wrapped in `PageContainerNotWidthConstrained`, but this time with the `$notConstrained` property set to `true`. This leads to no width constraint being set.

### Adding expand width function to stratigraphic table

The stratigraphic table showing horizons and zones, used on the RMS and Stratigraphy page, now has an icon in the top right corner. The table is initially set to the same width as the rest of the page, but clicking on this icon expands the table to use the full width of the page. The width can then be collapsed again. Whether the table is expanded or not is kept in state (using session storage), so the user can navigate to other pages and come back to the same table width as before.

Expansion and collapsing of the table width is handled by toggling the `$notConstrained` property of the `PageContainerNotWidthConstrained` component that the table is wrapped in. Note that whether the stratigraphic framework should offer the option to expand the width is controlled by the property `enableWidthExpansion`. The table is also used in an edit dialog, so there this option is not set.


## Checklist

- [ ] Tests added - not relevant
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [X] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
