### PR TITLE
BUG: Prevent clipping of selected value in drop-down widget

### DIFF
--- a/frontend/src/components/project/history/SnapshotHistory.style.ts
+++ b/frontend/src/components/project/history/SnapshotHistory.style.ts
@@ -19,18 +19,10 @@ const diffPalette: Record<DiffKind, { background: string; color: string }> = {
   },
 };
 
-export const ResourcePickerContainer = styled.div`
-  min-width: 13em;
-`;
-
 export const MaxSnapshotsControls = styled.div`
   display: flex;
   align-items: flex-end;
   gap: ${tokens.spacings.comfortable.small};
-`;
-
-export const MaxSnapshotsSelectContainer = styled.div`
-  min-width: 7em;
 `;
 
 export const SnapshotInfo = styled.div`

--- a/frontend/src/components/project/history/SnapshotHistory.tsx
+++ b/frontend/src/components/project/history/SnapshotHistory.tsx
@@ -49,8 +49,6 @@ import {
   DiffGroup,
   DiffLegend,
   MaxSnapshotsControls,
-  MaxSnapshotsSelectContainer,
-  ResourcePickerContainer,
   ScrollableCardStack,
   SelectorRow,
   SnapshotInfo,
@@ -801,7 +799,7 @@ export function SnapshotHistory({
           </PageText>
 
           <SelectorRow>
-            <ResourcePickerContainer>
+            <div>
               <NativeSelect
                 id="history-resource"
                 label="Settings type"
@@ -816,10 +814,10 @@ export function SnapshotHistory({
                   </option>
                 ))}
               </NativeSelect>
-            </ResourcePickerContainer>
+            </div>
 
             <MaxSnapshotsControls>
-              <MaxSnapshotsSelectContainer>
+              <div>
                 <NativeSelect
                   id="history-max-snapshots"
                   label="Max snapshots"
@@ -840,7 +838,7 @@ export function SnapshotHistory({
                     </option>
                   ))}
                 </NativeSelect>
-              </MaxSnapshotsSelectContainer>
+              </div>
 
               <GeneralButton
                 label="Save"

--- a/frontend/src/styles/global.ts
+++ b/frontend/src/styles/global.ts
@@ -6,6 +6,11 @@ const GlobalStyle = createGlobalStyle`
     font-family: "Equinor", sans-serif;
   }
 
+  /* Fixes to EDS components */
+  div[class^=NativeSelect__Container] {
+    padding-right: 12px;
+  }
+
   .Toastify__toast {
     overflow-y: auto;
   }


### PR DESCRIPTION
Resolves #422 

The bug affects all usage of the EDS drop-down widget, so the fix is placed in `styles/global.ts`. When similar fixes and adjustments of EDS components are needed, they can be placed here.

For the two drop-down widgets on the project history page, a fix was earlier made by setting a minimum width on a container. This is no longer needed, so the containers are now regular `div`.


## Checklist

- [ ] Tests added - not relevant
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [X] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [X] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [X] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [X] Moved issue status on project board
- [X] Checked the boxes in this checklist ✅
