### PR TITLE
BUG: Adapt SSO token handling to MSAL 5

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,4 +1,5 @@
 import {
+  type AccountInfo,
   type AuthenticationResult,
   type EventMessage,
   EventType,
@@ -214,12 +215,26 @@ export function App() {
 
   const acquireAndPatchSsoAccessToken = useCallback(async () => {
     acquireAndPatchSsoAccessTokenPromise.current ??= (async () => {
+      const account = msalInstance.getActiveAccount();
+      const accounts = msalInstance.getAllAccounts();
+
+      if (!account && accounts.length === 0) {
+        await msalInstance.acquireTokenRedirect({ scopes: ssoScopes });
+
+        return;
+      }
+
       const result = await msalInstance
-        .acquireTokenSilent({ scopes: ssoScopes })
+        .acquireTokenSilent({
+          scopes: ssoScopes,
+          account: account ?? accounts[0],
+        })
         .catch((error: unknown) => {
           if (error instanceof InteractionRequiredAuthError) {
             return msalInstance.acquireTokenRedirect({ scopes: ssoScopes });
           }
+
+          console.error("Error acquiring SSO token: ", error);
         });
 
       if (result) {
@@ -306,12 +321,11 @@ export function App() {
     const id = msalInstance.addEventCallback(
       (event: EventMessage) => {
         if (event.payload) {
-          const payload = event.payload as AuthenticationResult;
           if (event.eventType === EventType.LOGIN_SUCCESS) {
-            const account = payload.account;
+            const account = event.payload as AccountInfo;
             msalInstance.setActiveAccount(account);
-            void acquireAndPatchSsoAccessToken();
           } else if (event.eventType === EventType.ACQUIRE_TOKEN_SUCCESS) {
+            const payload = event.payload as AuthenticationResult;
             setAccessToken(payload.accessToken);
             if (event.interactionType === InteractionType.Redirect) {
               handleAddSsoAccessToken(
@@ -330,7 +344,7 @@ export function App() {
         msalInstance.removeEventCallback(id);
       }
     };
-  }, [acquireAndPatchSsoAccessToken, msalInstance, patchAccessTokenMutate]);
+  }, [msalInstance, patchAccessTokenMutate]);
 
   return (
     <RouterProvider


### PR DESCRIPTION
Resolves #435

Adapted SSO token handling to MSAL 5 event payloads. `LOGIN_SUCCESS` now sets the active account from the `AccountInfo` payload, while `ACQUIRE_TOKEN_SUCCESS` continues to handle the `AuthenticationResult` access
token. Stale SMDA token refresh now calls `acquireTokenSilent` with the active account, falling back to the single cached account.

Tested this by manually patching the `smda_api` token with a broken token and it retried after 401.
<img width="589" height="131" alt="2026-06-10_2-07-34 PM" src="https://github.com/user-attachments/assets/b17de4f5-13fd-4f02-867a-88828a5514f7" />
Easiet fix is to just revert back to MSAL 4, but I figured we can just adapt to the new MSAL 5.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
