### PR TITLE
ENH: Improve horizon dropdown lists

### DIFF
--- a/frontend/src/components/form/field.tsx
+++ b/frontend/src/components/form/field.tsx
@@ -35,7 +35,6 @@ export interface CommonTextFieldProps
 export interface OptionProps {
   value: string;
   label: string;
-  displayLabel?: string;
 }
 
 const helperTextLoadingOptions = "Loading options...";
@@ -215,7 +214,7 @@ export function Select({
       >
         {options.map((option) => (
           <option key={option.value} value={option.value}>
-            {option.displayLabel ?? option.label}
+            {option.label}
           </option>
         ))}
       </NativeSelect>

--- a/frontend/src/components/form/field.tsx
+++ b/frontend/src/components/form/field.tsx
@@ -35,6 +35,7 @@ export interface CommonTextFieldProps
 export interface OptionProps {
   value: string;
   label: string;
+  displayLabel?: string;
 }
 
 const helperTextLoadingOptions = "Loading options...";
@@ -214,7 +215,7 @@ export function Select({
       >
         {options.map((option) => (
           <option key={option.value} value={option.value}>
-            {option.label}
+            {option.displayLabel ?? option.label}
           </option>
         ))}
       </NativeSelect>

--- a/frontend/src/components/project/stratigraphy/Overview.tsx
+++ b/frontend/src/components/project/stratigraphy/Overview.tsx
@@ -397,12 +397,6 @@ function Elements({
   const [activeElementMapping, setActiveElementMapping] = useState<
     ElementMapping | undefined
   >();
-  const [smdaNameOptions, setSmdaNameOptions] = useState<
-    Record<ElementType, OptionProps[]>
-  >({
-    horizon: [...createSpecialOptions("horizon", false)],
-    zone: [...createSpecialOptions("zone", false)],
-  } as Record<ElementType, OptionProps[]>);
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const queryClient = useQueryClient();
   const frameworkData = useFrameworkData();
@@ -478,50 +472,48 @@ function Elements({
     setElementMappings(elementMappings);
   }, [frameworkData.horizons, frameworkData.zones, stratigraphyMappings]);
 
-  useEffect(() => {
-    if (stratigraphicUnits !== undefined) {
-      setSmdaNameOptions((options) => ({
-        ...options,
-        zone: [
-          ...createSpecialOptions(
-            "zone",
-            stratigraphicUnits.stratigraphic_units.length > 0,
-          ),
-          ...createStratUnitOptions(stratigraphicUnits.stratigraphic_units),
-        ],
-      }));
-    }
-  }, [stratigraphicUnits]);
-
-  const editSmdaNameOptions = useMemo(() => {
-    if (
-      activeElementMapping?.elementType !== "horizon" ||
-      stratigraphicUnits === undefined
-    ) {
-      return smdaNameOptions;
+  const horizonOptionsData = useMemo(() => {
+    if (stratigraphicUnits === undefined) {
+      return { options: [], horizonNamesByUuid: {} };
     }
 
-    const horizon = createHorizonOptions(
-      activeElementMapping.rmsName,
+    return createHorizonOptions(
+      activeElementMapping?.elementType === "horizon"
+        ? activeElementMapping.rmsName
+        : "",
       frameworkData.zones,
       elementMappings,
       stratigraphicUnits.stratigraphic_units,
     );
-
-    return {
-      ...smdaNameOptions,
-      horizon: [
-        ...createSpecialOptions("horizon", horizon.length > 0),
-        ...horizon,
-      ],
-    };
   }, [
     activeElementMapping,
     elementMappings,
     frameworkData.zones,
-    smdaNameOptions,
     stratigraphicUnits,
   ]);
+
+  const smdaNameOptions = useMemo(
+    () =>
+      ({
+        horizon: [
+          ...createSpecialOptions(
+            "horizon",
+            horizonOptionsData.options.length > 0,
+          ),
+          ...horizonOptionsData.options,
+        ],
+        zone: [
+          ...createSpecialOptions(
+            "zone",
+            (stratigraphicUnits?.stratigraphic_units.length ?? 0) > 0,
+          ),
+          ...createStratUnitOptions(
+            stratigraphicUnits?.stratigraphic_units ?? [],
+          ),
+        ],
+      }) as Record<ElementType, OptionProps[]>,
+    [horizonOptionsData.options, stratigraphicUnits],
+  );
 
   const editClick = (elementMapping: ElementMapping) => {
     setActiveElementMapping(elementMapping);
@@ -541,14 +533,13 @@ function Elements({
     const stratUnit = stratigraphicUnits?.stratigraphic_units.find(
       (unit) => unit.uuid === formValue.smdaUuid,
     );
+    const smdaName =
+      formValue.elementType === "horizon"
+        ? (horizonOptionsData.horizonNamesByUuid[formValue.smdaUuid] ?? "")
+        : (stratUnit?.identifier ?? "");
 
     const mutationValue = createMutationValue(
-      updatedElementMappings(
-        elementMappings,
-        formValue,
-        editSmdaNameOptions,
-        stratUnit,
-      ),
+      updatedElementMappings(elementMappings, formValue, smdaName),
     );
 
     mappingsMutation.mutate(
@@ -559,12 +550,7 @@ function Elements({
       {
         onSuccess: (data) => {
           setElementMappings((elementMappings) =>
-            updatedElementMappings(
-              elementMappings,
-              formValue,
-              editSmdaNameOptions,
-              stratUnit,
-            ),
+            updatedElementMappings(elementMappings, formValue, smdaName),
           );
           formSubmitCallback({ message: data.message, formReset });
           closeEditDialog();
@@ -578,7 +564,7 @@ function Elements({
       {editDialogOpen && (
         <Edit
           elementMapping={activeElementMapping}
-          smdaNameOptions={editSmdaNameOptions}
+          smdaNameOptions={smdaNameOptions}
           projectReadOnly={projectReadOnly}
           mutationCallback={mutationCallback}
           optionsIsPending={stratigraphicUnitsPending}

--- a/frontend/src/components/project/stratigraphy/Overview.tsx
+++ b/frontend/src/components/project/stratigraphy/Overview.tsx
@@ -59,6 +59,7 @@ import {
 } from "../stratigraphicFramework/functions";
 import { StratigraphicFramework } from "../stratigraphicFramework/StratigraphicFramework";
 import {
+  createHorizonOptions,
   createMutationValue,
   createStratigraphyMappingsLookup,
   createStratUnitOptions,
@@ -492,39 +493,35 @@ function Elements({
     }
   }, [stratigraphicUnits]);
 
-  useEffect(() => {
-    if (stratigraphicUnits !== undefined) {
-      const smdaUuids = Object.values(elementMappings)
-        .filter(
-          (mapping) =>
-            mapping.elementType === "zone" &&
-            !mapping.unmappable &&
-            mapping.smdaUuid !== "",
-        )
-        .map((mapping) => mapping.smdaUuid);
-
-      const horizonOptions: OptionProps[] =
-        stratigraphicUnits.stratigraphic_units
-          .filter(
-            (unit) =>
-              smdaUuids.includes(unit.uuid) &&
-              unit.top_uuid !== null &&
-              unit.base_uuid !== null,
-          )
-          .flatMap((unit) => [
-            { value: unit.top_uuid ?? "", label: unit.top },
-            { value: unit.base_uuid ?? "", label: unit.base },
-          ]);
-
-      setSmdaNameOptions((options) => ({
-        ...options,
-        horizon: [
-          ...createSpecialOptions("horizon", horizonOptions.length > 0),
-          ...horizonOptions,
-        ],
-      }));
+  const editSmdaNameOptions = useMemo(() => {
+    if (
+      activeElementMapping?.elementType !== "horizon" ||
+      stratigraphicUnits === undefined
+    ) {
+      return smdaNameOptions;
     }
-  }, [elementMappings, stratigraphicUnits]);
+
+    const horizon = createHorizonOptions(
+      activeElementMapping.rmsName,
+      frameworkData.zones,
+      elementMappings,
+      stratigraphicUnits.stratigraphic_units,
+    );
+
+    return {
+      ...smdaNameOptions,
+      horizon: [
+        ...createSpecialOptions("horizon", horizon.length > 0),
+        ...horizon,
+      ],
+    };
+  }, [
+    activeElementMapping,
+    elementMappings,
+    frameworkData.zones,
+    smdaNameOptions,
+    stratigraphicUnits,
+  ]);
 
   const editClick = (elementMapping: ElementMapping) => {
     setActiveElementMapping(elementMapping);
@@ -549,7 +546,7 @@ function Elements({
       updatedElementMappings(
         elementMappings,
         formValue,
-        smdaNameOptions,
+        editSmdaNameOptions,
         stratUnit,
       ),
     );
@@ -565,7 +562,7 @@ function Elements({
             updatedElementMappings(
               elementMappings,
               formValue,
-              smdaNameOptions,
+              editSmdaNameOptions,
               stratUnit,
             ),
           );
@@ -581,7 +578,7 @@ function Elements({
       {editDialogOpen && (
         <Edit
           elementMapping={activeElementMapping}
-          smdaNameOptions={smdaNameOptions}
+          smdaNameOptions={editSmdaNameOptions}
           projectReadOnly={projectReadOnly}
           mutationCallback={mutationCallback}
           optionsIsPending={stratigraphicUnitsPending}
@@ -709,8 +706,9 @@ export function Overview({
             <PageSectionWidthConstrained>
               {stratigraphicColumn ? (
                 <PageText>
-                  💡 Set SMDA names for zones first. Horizon options are derived
-                  from the top and base horizons of mapped zones.
+                  💡 Set SMDA names for zones first. When a zone directly above
+                  or below a horizon is mapped, its horizons are listed at the
+                  top of that horizon's options for easier selection.
                 </PageText>
               ) : (
                 <WarningBox>

--- a/frontend/src/components/project/stratigraphy/functions.ts
+++ b/frontend/src/components/project/stratigraphy/functions.ts
@@ -12,7 +12,6 @@ import { findOptionValueInOptionsArray } from "#utils/form";
 import type {
   ElementMapping,
   ElementMappings,
-  ElementType,
   StratUnitRelation,
 } from "./types";
 import {
@@ -124,7 +123,7 @@ export function createHorizonOptions(
   zones: RmsStratigraphicZone[],
   elementMappings: ElementMappings,
   stratigraphicUnits: StratigraphicUnit[],
-): OptionProps[] {
+): { options: OptionProps[]; horizonNamesByUuid: Record<string, string> } {
   const zoneNamesByHorizon = new Map<string, Set<string>>();
   zones
     .filter(
@@ -159,6 +158,7 @@ export function createHorizonOptions(
 
   const adjacentHorizonOptions: OptionProps[] = [];
   const otherHorizonOptions: OptionProps[] = [];
+  const horizonNamesByUuid: Record<string, string> = {};
   const seenHorizonUuids = new Set<string>();
   stratigraphicUnits.forEach((unit) => {
     (
@@ -171,13 +171,13 @@ export function createHorizonOptions(
         return;
       }
       seenHorizonUuids.add(horizonUuid);
+      horizonNamesByUuid[horizonUuid] = horizonName;
 
       const zoneNames = zoneNamesByHorizon.get(horizonUuid);
       if (zoneNames) {
         adjacentHorizonOptions.push({
           value: horizonUuid,
-          label: horizonName,
-          displayLabel: `${horizonName} [${[...zoneNames].join(", ")}]`,
+          label: `${horizonName} [${[...zoneNames].join(", ")}]`,
         });
       } else {
         otherHorizonOptions.push({ value: horizonUuid, label: horizonName });
@@ -185,14 +185,16 @@ export function createHorizonOptions(
     });
   });
 
-  return [...adjacentHorizonOptions, ...otherHorizonOptions];
+  return {
+    options: [...adjacentHorizonOptions, ...otherHorizonOptions],
+    horizonNamesByUuid,
+  };
 }
 
 export function updatedElementMappings(
   elementMappings: ElementMappings,
   value: ElementMapping,
-  smdaNameOptions: Record<ElementType, OptionProps[]>,
-  stratUnit?: StratigraphicUnit,
+  smdaName: string,
 ) {
   if (value.smdaUuid === specialOptions.empty.value) {
     return {
@@ -223,14 +225,7 @@ export function updatedElementMappings(
       [value.rmsName]: {
         ...value,
         unmappable: false,
-        smdaName:
-          value.elementType === "horizon"
-            ? (
-                smdaNameOptions.horizon.find(
-                  (option) => option.value === value.smdaUuid,
-                ) ?? { value: "", label: "" }
-              ).label
-            : (stratUnit?.identifier ?? ""),
+        smdaName,
       },
     } as ElementMappings;
   }

--- a/frontend/src/components/project/stratigraphy/functions.ts
+++ b/frontend/src/components/project/stratigraphy/functions.ts
@@ -4,6 +4,7 @@ import type {
   DataSystem,
   InternalStratigraphyMappingsOutput,
   MappingType,
+  RmsStratigraphicZone,
   StratigraphicUnit,
 } from "#client";
 import type { OptionProps } from "#components/form/field";
@@ -116,6 +117,75 @@ export function createStratUnitOptions(stratUnits: StratigraphicUnit[]) {
   }
 
   return getOptionPropsForChildren(relations, 1);
+}
+
+export function createHorizonOptions(
+  rmsHorizonName: string,
+  zones: RmsStratigraphicZone[],
+  elementMappings: ElementMappings,
+  stratigraphicUnits: StratigraphicUnit[],
+): OptionProps[] {
+  const zoneNamesByHorizon = new Map<string, Set<string>>();
+  zones
+    .filter(
+      (zone) =>
+        zone.top_horizon_name === rmsHorizonName ||
+        zone.base_horizon_name === rmsHorizonName,
+    )
+    .forEach((zone) => {
+      const zoneMapping = elementMappings[zone.name];
+      if (zoneMapping.unmappable || zoneMapping.smdaUuid === "") {
+        return;
+      }
+
+      const mappedUnit = stratigraphicUnits.find(
+        (unit) => unit.uuid === zoneMapping.smdaUuid,
+      );
+      // The relevant suggestion is the zone boundary that coincides with the
+      // edited horizon: the base of a zone above, the top of a zone below.
+      const horizonUuid =
+        zone.base_horizon_name === rmsHorizonName
+          ? mappedUnit?.base_uuid
+          : mappedUnit?.top_uuid;
+      if (!mappedUnit || !horizonUuid) {
+        return;
+      }
+
+      const zoneNames =
+        zoneNamesByHorizon.get(horizonUuid) ?? new Set<string>();
+      zoneNames.add(mappedUnit.identifier);
+      zoneNamesByHorizon.set(horizonUuid, zoneNames);
+    });
+
+  const adjacentHorizonOptions: OptionProps[] = [];
+  const otherHorizonOptions: OptionProps[] = [];
+  const seenHorizonUuids = new Set<string>();
+  stratigraphicUnits.forEach((unit) => {
+    (
+      [
+        [unit.top_uuid, unit.top],
+        [unit.base_uuid, unit.base],
+      ] as const
+    ).forEach(([horizonUuid, horizonName]) => {
+      if (!horizonUuid || seenHorizonUuids.has(horizonUuid)) {
+        return;
+      }
+      seenHorizonUuids.add(horizonUuid);
+
+      const zoneNames = zoneNamesByHorizon.get(horizonUuid);
+      if (zoneNames) {
+        adjacentHorizonOptions.push({
+          value: horizonUuid,
+          label: horizonName,
+          displayLabel: `${horizonName} [${[...zoneNames].join(", ")}]`,
+        });
+      } else {
+        otherHorizonOptions.push({ value: horizonUuid, label: horizonName });
+      }
+    });
+  });
+
+  return [...adjacentHorizonOptions, ...otherHorizonOptions];
 }
 
 export function updatedElementMappings(


### PR DESCRIPTION
Resolves #414

- Deduped horizon options by UUID and show the full list of horizon options 
- Horizons from associated zones are listed on top. When a zone directly above or below a horizon is mapped, its horizons are showed at the top of that horizon's options and annotated with the source zone name for easier selection. This added label is similar to what we have in masterdata editing for stratigraphic column and coordinate system.

Example:

When mapping TopTherys horizon, using JS strat column as mapping example, we got Balder Fm. Base and Sele Fm. Top as suggestions on top of the list.
<img width="1028" height="688" alt="2026-06-10_2-47-13 PM" src="https://github.com/user-attachments/assets/5ef50e92-2ce4-4ff8-aefa-dfb4bafddfbd" />

In Drogon, when mapping TopVolantis horizon, we got VOLANTIS GP. Top as suggested horizon, because both Valysar Fm. and VOLANTIS GP. zone have VOLANTIS GP. Top as their top horizon name.
<img width="925" height="810" alt="2026-06-10_2-48-37 PM" src="https://github.com/user-attachments/assets/49167d5b-ea01-4093-9468-392dda8f11d5" />


## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
