### PR TITLE
MAINT: Add HTTP constant for 404

### DIFF
--- a/frontend/src/components/ProjectRecoveryNotification.tsx
+++ b/frontend/src/components/ProjectRecoveryNotification.tsx
@@ -14,7 +14,7 @@ import type { CacheResource } from "#client/types.gen";
 import { CancelButton, GeneralButton } from "#components/form/button";
 import { useProject } from "#services/project";
 import { GenericDialog, PageText } from "#styles/common";
-import { HTTP_STATUS_UNPROCESSABLE_CONTENT } from "#utils/api";
+import { HTTP_STATUS_422_UNPROCESSABLE_CONTENT } from "#utils/api";
 
 const CACHE_RESOURCE_PROJECT_CONFIG: CacheResource = "config.json";
 
@@ -79,7 +79,7 @@ export function ProjectRecoveryNotification() {
       }
     }
 
-    if (project.errorStatus === HTTP_STATUS_UNPROCESSABLE_CONTENT) {
+    if (project.errorStatus === HTTP_STATUS_422_UNPROCESSABLE_CONTENT) {
       void checkSnapshots();
     } else {
       setLatestRevision(null);

--- a/frontend/src/components/home/Changelog.tsx
+++ b/frontend/src/components/home/Changelog.tsx
@@ -28,8 +28,7 @@ function Content() {
       !(
         isAxiosError(queryError) &&
         queryError.response?.status === HTTP_STATUS_404_NOT_FOUND
-      ) &&
-      failureCount < 3,
+      ) && failureCount < 3,
   });
 
   if (data.length === 0) {

--- a/frontend/src/components/home/Changelog.tsx
+++ b/frontend/src/components/home/Changelog.tsx
@@ -5,6 +5,7 @@ import { Suspense } from "react";
 import { projectGetChangelogOptions } from "#client/@tanstack/react-query.gen";
 import { Loading, QueryErrorBoundary } from "#components/common";
 import { PageHeader, PageText } from "#styles/common";
+import { HTTP_STATUS_404_NOT_FOUND } from "#utils/api";
 import { displayDateTime } from "#utils/datetime";
 import {
   ChangeDescription,
@@ -20,11 +21,14 @@ function Content() {
   const { data } = useSuspenseQuery({
     ...projectGetChangelogOptions(),
     meta: {
-      preventDefaultErrorHandling: [404],
-      resetQueryOnError: [404],
+      preventDefaultErrorHandling: [HTTP_STATUS_404_NOT_FOUND],
+      resetQueryOnError: [HTTP_STATUS_404_NOT_FOUND],
     },
     retry: (failureCount, queryError) =>
-      !(isAxiosError(queryError) && queryError.response?.status === 404) &&
+      !(
+        isAxiosError(queryError) &&
+        queryError.response?.status === HTTP_STATUS_404_NOT_FOUND
+      ) &&
       failureCount < 3,
   });
 
@@ -82,7 +86,7 @@ export function Changelog() {
 
       <QueryErrorBoundary
         statusCodeHandling={{
-          404: {
+          [HTTP_STATUS_404_NOT_FOUND]: {
             message: "No changelog found for this project.",
             enableRetry: false,
           },

--- a/frontend/src/components/project/masterdata/Edit.tsx
+++ b/frontend/src/components/project/masterdata/Edit.tsx
@@ -46,7 +46,7 @@ import {
   PageText,
 } from "#styles/common";
 import {
-  HTTP_STATUS_UNPROCESSABLE_CONTENT,
+  HTTP_STATUS_422_UNPROCESSABLE_CONTENT,
   httpValidationErrorToString,
 } from "#utils/api";
 import {
@@ -340,7 +340,7 @@ export function Edit({
       });
     },
     onError: (error) => {
-      if (error.response?.status === HTTP_STATUS_UNPROCESSABLE_CONTENT) {
+      if (error.response?.status === HTTP_STATUS_422_UNPROCESSABLE_CONTENT) {
         const message = httpValidationErrorToString(error);
         console.error(message);
         toast.error(message, { autoClose: false });
@@ -348,7 +348,7 @@ export function Edit({
     },
     meta: {
       errorPrefix: "Error saving masterdata",
-      preventDefaultErrorHandling: [HTTP_STATUS_UNPROCESSABLE_CONTENT],
+      preventDefaultErrorHandling: [HTTP_STATUS_422_UNPROCESSABLE_CONTENT],
     },
   });
 

--- a/frontend/src/components/project/overview/Access.tsx
+++ b/frontend/src/components/project/overview/Access.tsx
@@ -36,7 +36,7 @@ import {
   PageText,
 } from "#styles/common";
 import {
-  HTTP_STATUS_UNPROCESSABLE_CONTENT,
+  HTTP_STATUS_422_UNPROCESSABLE_CONTENT,
   httpValidationErrorToString,
 } from "#utils/api";
 import { fieldContext, formContext } from "#utils/form";
@@ -113,7 +113,7 @@ function AccessEditorForm({
       });
     },
     onError: (error) => {
-      if (error.response?.status === HTTP_STATUS_UNPROCESSABLE_CONTENT) {
+      if (error.response?.status === HTTP_STATUS_422_UNPROCESSABLE_CONTENT) {
         const message = httpValidationErrorToString(error);
         console.error(message);
         toast.error(message, { autoClose: false });
@@ -121,7 +121,7 @@ function AccessEditorForm({
     },
     meta: {
       errorPrefix: "Error saving access information",
-      preventDefaultErrorHandling: [HTTP_STATUS_UNPROCESSABLE_CONTENT],
+      preventDefaultErrorHandling: [HTTP_STATUS_422_UNPROCESSABLE_CONTENT],
     },
   });
 

--- a/frontend/src/components/project/overview/Model.tsx
+++ b/frontend/src/components/project/overview/Model.tsx
@@ -26,7 +26,7 @@ import {
   PageText,
 } from "#styles/common";
 import {
-  HTTP_STATUS_UNPROCESSABLE_CONTENT,
+  HTTP_STATUS_422_UNPROCESSABLE_CONTENT,
   httpValidationErrorToString,
 } from "#utils/api";
 import { fieldContext, formContext } from "#utils/form";
@@ -72,7 +72,7 @@ function ModelEditorForm({
       });
     },
     onError: (error) => {
-      if (error.response?.status === HTTP_STATUS_UNPROCESSABLE_CONTENT) {
+      if (error.response?.status === HTTP_STATUS_422_UNPROCESSABLE_CONTENT) {
         const message = httpValidationErrorToString(error);
         console.error(message);
         toast.error(message, { autoClose: false });
@@ -80,7 +80,7 @@ function ModelEditorForm({
     },
     meta: {
       errorPrefix: "Error saving model information",
-      preventDefaultErrorHandling: [HTTP_STATUS_UNPROCESSABLE_CONTENT],
+      preventDefaultErrorHandling: [HTTP_STATUS_422_UNPROCESSABLE_CONTENT],
     },
   });
 

--- a/frontend/src/components/project/overview/ProjectSelector.tsx
+++ b/frontend/src/components/project/overview/ProjectSelector.tsx
@@ -80,7 +80,12 @@ function ProjectSelectorForm({
   const [helperTextRecentProjects, sethelperTextRecentProjects] = useState("");
   const [helperTextProjectPath, setHelperTextProjectPath] = useState("");
   const [valueSource, setValueSource] = useState<ValueSource>("");
-  const codes = [403, HTTP_STATUS_404_NOT_FOUND, 409, HTTP_STATUS_UNPROCESSABLE_CONTENT];
+  const codes = [
+    403,
+    HTTP_STATUS_404_NOT_FOUND,
+    409,
+    HTTP_STATUS_UNPROCESSABLE_CONTENT,
+  ];
 
   const closeProjectSelector = ({ formReset }: { formReset: () => void }) => {
     sethelperTextRecentProjects("");

--- a/frontend/src/components/project/overview/ProjectSelector.tsx
+++ b/frontend/src/components/project/overview/ProjectSelector.tsx
@@ -31,7 +31,10 @@ import { CancelButton, SubmitButton } from "#components/form/button";
 import { TextField } from "#components/form/field";
 import { mappingsPaths } from "#services/project";
 import { EditDialog, PageSectionSpacer, PageText } from "#styles/common";
-import { HTTP_STATUS_UNPROCESSABLE_CONTENT } from "#utils/api";
+import {
+  HTTP_STATUS_404_NOT_FOUND,
+  HTTP_STATUS_UNPROCESSABLE_CONTENT,
+} from "#utils/api";
 import {
   fieldContext,
   formContext,
@@ -77,7 +80,7 @@ function ProjectSelectorForm({
   const [helperTextRecentProjects, sethelperTextRecentProjects] = useState("");
   const [helperTextProjectPath, setHelperTextProjectPath] = useState("");
   const [valueSource, setValueSource] = useState<ValueSource>("");
-  const codes = [403, 404, 409, HTTP_STATUS_UNPROCESSABLE_CONTENT];
+  const codes = [403, HTTP_STATUS_404_NOT_FOUND, 409, HTTP_STATUS_UNPROCESSABLE_CONTENT];
 
   const closeProjectSelector = ({ formReset }: { formReset: () => void }) => {
     sethelperTextRecentProjects("");
@@ -171,7 +174,7 @@ function ProjectSelectorForm({
 
             if (status && codes.includes(status)) {
               if (
-                status === 404 &&
+                status === HTTP_STATUS_404_NOT_FOUND &&
                 detail === `No .fmu directory found at ${path}`
               ) {
                 setInitConfirmDialogOpen(true);
@@ -185,7 +188,10 @@ function ProjectSelectorForm({
                 setHelperTextProjectPath(detail);
               }
 
-              if (status === 404 && detail === `Path ${path} does not exist`) {
+              if (
+                status === HTTP_STATUS_404_NOT_FOUND &&
+                detail === `Path ${path} does not exist`
+              ) {
                 void queryClient.invalidateQueries({
                   queryKey: userGetUserQueryKey(),
                 });

--- a/frontend/src/components/project/overview/ProjectSelector.tsx
+++ b/frontend/src/components/project/overview/ProjectSelector.tsx
@@ -32,8 +32,10 @@ import { TextField } from "#components/form/field";
 import { mappingsPaths } from "#services/project";
 import { EditDialog, PageSectionSpacer, PageText } from "#styles/common";
 import {
+  HTTP_STATUS_403_FORBIDDEN,
   HTTP_STATUS_404_NOT_FOUND,
-  HTTP_STATUS_UNPROCESSABLE_CONTENT,
+  HTTP_STATUS_409_CONFLICT,
+  HTTP_STATUS_422_UNPROCESSABLE_CONTENT,
 } from "#utils/api";
 import {
   fieldContext,
@@ -81,10 +83,10 @@ function ProjectSelectorForm({
   const [helperTextProjectPath, setHelperTextProjectPath] = useState("");
   const [valueSource, setValueSource] = useState<ValueSource>("");
   const codes = [
-    403,
+    HTTP_STATUS_403_FORBIDDEN,
     HTTP_STATUS_404_NOT_FOUND,
-    409,
-    HTTP_STATUS_UNPROCESSABLE_CONTENT,
+    HTTP_STATUS_409_CONFLICT,
+    HTTP_STATUS_422_UNPROCESSABLE_CONTENT,
   ];
 
   const closeProjectSelector = ({ formReset }: { formReset: () => void }) => {
@@ -164,7 +166,7 @@ function ProjectSelectorForm({
             const detail = (error.response?.data as { detail: string }).detail;
             const status = error.status;
 
-            if (status === HTTP_STATUS_UNPROCESSABLE_CONTENT) {
+            if (status === HTTP_STATUS_422_UNPROCESSABLE_CONTENT) {
               void queryClient.invalidateQueries({
                 queryKey: projectGetProjectQueryKey(),
               });

--- a/frontend/src/components/project/rms/Overview.tsx
+++ b/frontend/src/components/project/rms/Overview.tsx
@@ -32,7 +32,7 @@ import {
   PageText,
 } from "#styles/common";
 import {
-  HTTP_STATUS_UNPROCESSABLE_CONTENT,
+  HTTP_STATUS_422_UNPROCESSABLE_CONTENT,
   httpValidationErrorToString,
 } from "#utils/api";
 import { fieldContext, formContext } from "#utils/form";
@@ -95,7 +95,7 @@ function RmsEditorForm({
       });
     },
     onError: (error) => {
-      if (error.response?.status === HTTP_STATUS_UNPROCESSABLE_CONTENT) {
+      if (error.response?.status === HTTP_STATUS_422_UNPROCESSABLE_CONTENT) {
         const message = httpValidationErrorToString(error);
         console.error(message);
         toast.error(message, { autoClose: false });
@@ -103,7 +103,7 @@ function RmsEditorForm({
     },
     meta: {
       errorPrefix: "Error saving the RMS project",
-      preventDefaultErrorHandling: [HTTP_STATUS_UNPROCESSABLE_CONTENT],
+      preventDefaultErrorHandling: [HTTP_STATUS_422_UNPROCESSABLE_CONTENT],
     },
   });
 
@@ -274,7 +274,7 @@ function RmsProjectActions({
         return;
       }
 
-      if (error.response?.status === HTTP_STATUS_UNPROCESSABLE_CONTENT) {
+      if (error.response?.status === HTTP_STATUS_422_UNPROCESSABLE_CONTENT) {
         const message = (error.response.data as { detail?: string }).detail;
         console.error(message);
         toast.error(message, { autoClose: false });
@@ -282,7 +282,7 @@ function RmsProjectActions({
     },
     meta: {
       errorPrefix: "Error accessing the RMS project",
-      preventDefaultErrorHandling: [HTTP_STATUS_UNPROCESSABLE_CONTENT],
+      preventDefaultErrorHandling: [HTTP_STATUS_422_UNPROCESSABLE_CONTENT],
     },
   });
 

--- a/frontend/src/components/project/rms/Stratigraphy.tsx
+++ b/frontend/src/components/project/rms/Stratigraphy.tsx
@@ -36,7 +36,7 @@ import {
   PageText,
 } from "#styles/common";
 import {
-  HTTP_STATUS_UNPROCESSABLE_CONTENT,
+  HTTP_STATUS_422_UNPROCESSABLE_CONTENT,
   httpValidationErrorToString,
 } from "#utils/api.ts";
 import { fieldContext, formContext, useFormContext } from "#utils/form";
@@ -319,7 +319,7 @@ function Edit({
       });
     },
     onError: (error) => {
-      if (error.response?.status === HTTP_STATUS_UNPROCESSABLE_CONTENT) {
+      if (error.response?.status === HTTP_STATUS_422_UNPROCESSABLE_CONTENT) {
         const message = httpValidationErrorToString(error);
         console.error(message);
         toast.error(message, { autoClose: false });
@@ -327,7 +327,7 @@ function Edit({
     },
     meta: {
       errorPrefix: "Error updating project stratigraphy",
-      preventDefaultErrorHandling: [HTTP_STATUS_UNPROCESSABLE_CONTENT],
+      preventDefaultErrorHandling: [HTTP_STATUS_422_UNPROCESSABLE_CONTENT],
     },
   });
 

--- a/frontend/src/components/project/stratigraphy/Overview.tsx
+++ b/frontend/src/components/project/stratigraphy/Overview.tsx
@@ -48,7 +48,7 @@ import {
   WarningBox,
 } from "#styles/common";
 import {
-  HTTP_STATUS_UNPROCESSABLE_CONTENT,
+  HTTP_STATUS_422_UNPROCESSABLE_CONTENT,
   httpValidationErrorToString,
 } from "#utils/api";
 import { fieldContext, formContext } from "#utils/form";
@@ -438,7 +438,7 @@ function Elements({
       });
     },
     onError: (error) => {
-      if (error.response?.status === HTTP_STATUS_UNPROCESSABLE_CONTENT) {
+      if (error.response?.status === HTTP_STATUS_422_UNPROCESSABLE_CONTENT) {
         const message = httpValidationErrorToString(error);
         console.error(message);
         toast.error(message, { autoClose: false });
@@ -446,7 +446,7 @@ function Elements({
     },
     meta: {
       errorPrefix: "Error saving stratigraphy mapping",
-      preventDefaultErrorHandling: [HTTP_STATUS_UNPROCESSABLE_CONTENT],
+      preventDefaultErrorHandling: [HTTP_STATUS_422_UNPROCESSABLE_CONTENT],
     },
   });
 

--- a/frontend/src/services/project.ts
+++ b/frontend/src/services/project.ts
@@ -20,7 +20,7 @@ import {
 } from "#client/@tanstack/react-query.gen";
 import type { LockStatus, ProjectGetMappingsData } from "#client/types.gen";
 import { projectLockStatusRefetchInterval } from "#config";
-import { HTTP_STATUS_UNAUTHORIZED } from "#utils/api";
+import { HTTP_STATUS_401_UNAUTHORIZED } from "#utils/api";
 import type { QueryServiceBase } from "#utils/query";
 
 export type MappingsPathOptions = ProjectGetMappingsData["path"];
@@ -55,7 +55,7 @@ export function useProject(options?: Options<ProjectGetProjectData>) {
           if (isAxiosError(error)) {
             errorStatus = error.status;
             // Use normal handling for unauthorized response
-            if (error.status === HTTP_STATUS_UNAUTHORIZED) {
+            if (error.status === HTTP_STATUS_401_UNAUTHORIZED) {
               return Promise.reject(error);
             }
             if (error.response?.data && "detail" in error.response.data) {

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -3,6 +3,7 @@ import type { AxiosError } from "axios";
 import type { ValidationError } from "#client";
 
 export const HTTP_STATUS_UNAUTHORIZED = 401;
+export const HTTP_STATUS_404_NOT_FOUND = 404;
 export const HTTP_STATUS_UNPROCESSABLE_CONTENT = 422;
 
 export function httpValidationErrorToString(

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -2,9 +2,11 @@ import type { AxiosError } from "axios";
 
 import type { ValidationError } from "#client";
 
-export const HTTP_STATUS_UNAUTHORIZED = 401;
+export const HTTP_STATUS_401_UNAUTHORIZED = 401;
+export const HTTP_STATUS_403_FORBIDDEN = 403;
 export const HTTP_STATUS_404_NOT_FOUND = 404;
-export const HTTP_STATUS_UNPROCESSABLE_CONTENT = 422;
+export const HTTP_STATUS_409_CONFLICT = 409;
+export const HTTP_STATUS_422_UNPROCESSABLE_CONTENT = 422;
 
 export function httpValidationErrorToString(
   error: AxiosError,

--- a/frontend/src/utils/authentication.ts
+++ b/frontend/src/utils/authentication.ts
@@ -22,7 +22,7 @@ import type {
 } from "#client";
 import { client } from "#client/client.gen";
 import { ssoScopes } from "#config";
-import { HTTP_STATUS_UNAUTHORIZED } from "./api";
+import { HTTP_STATUS_401_UNAUTHORIZED } from "./api";
 import {
   getStorageItem,
   removeStorageItem,
@@ -162,7 +162,7 @@ export const responseInterceptorRejected =
     acquireAndPatchSsoAccessToken: () => Promise<void>,
   ) =>
   async (error: AxiosError) => {
-    if (error.status === HTTP_STATUS_UNAUTHORIZED) {
+    if (error.status === HTTP_STATUS_401_UNAUTHORIZED) {
       if (isApiUrlSession(error.response?.config.url)) {
         if (isApiTokenNonEmpty(apiToken)) {
           setApiToken(() => "");

--- a/frontend/src/utils/query.ts
+++ b/frontend/src/utils/query.ts
@@ -1,7 +1,7 @@
 import { isAxiosError } from "axios";
 import { toast } from "react-toastify";
 
-import { HTTP_STATUS_UNAUTHORIZED } from "./api";
+import { HTTP_STATUS_401_UNAUTHORIZED } from "./api";
 import { isApiUrlSession, isExternalApi } from "./authentication";
 
 export type QueryServiceBase<T> = {
@@ -34,7 +34,7 @@ export const defaultErrorHandling = (error: Error, errorPrefix: string) => {
 export const mutationRetry = (failureCount: number, error: Error) => {
   if (
     isAxiosError(error) &&
-    error.status === HTTP_STATUS_UNAUTHORIZED &&
+    error.status === HTTP_STATUS_401_UNAUTHORIZED &&
     !(
       isApiUrlSession(error.response?.config.url) ||
       isExternalApi(error.response?.headers)


### PR DESCRIPTION
Resolves #438 

Added a shared HTTP status constant for 404 and replaced hardcoded usages in handwritten frontend code to improve consistency and maintainability.

Updated comment : After PR review and suggestions all HTTP status that were hard coded were updated as constant along with their relevant usage in their respective files . 

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
