### PR TITLE
BUG: Retry RMS open only on unsupported version errors

### DIFF
--- a/frontend/src/components/project/rms/Overview.tsx
+++ b/frontend/src/components/project/rms/Overview.tsx
@@ -267,15 +267,20 @@ function RmsProjectActions({
     onError: (error, variables) => {
       setIsRmsProjectOpen(false);
 
-      // If version was specified, retry without to use actual version
-      if (variables.body?.version) {
-        projectOpenMutation.mutate({});
-
-        return;
-      }
-
       if (error.response?.status === HTTP_STATUS_422_UNPROCESSABLE_CONTENT) {
         const message = (error.response.data as { detail?: string }).detail;
+
+        // If version was specified, retry without to use actual version
+        if (
+          variables.body?.version &&
+          message?.includes("RMS version") &&
+          message.includes("is not supported")
+        ) {
+          projectOpenMutation.mutate({});
+
+          return;
+        }
+
         console.error(message);
         toast.error(message, { autoClose: false });
       }


### PR DESCRIPTION
Resolves #430 

GUI will automatically try to open RMS with `rmsMinimumVersion = 15.0.1.0` if the RMS version in config is less than that. If the request fails, it will retry without specifying RMS version, so the API will decide the RMS version to use. 

However, current implementation always retry on every error. This could lead to unnecessary retries, like retry on 404, which doesn't help because the RMS project is not found. With this fix, it will only retry on 422, and only when the error message is about RMS version is not supported, because there are other 422 errors like "Unable to check out required license." and else.

## Checklist

- [x] Tests added (if not, comment why): not relevant
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
