### PR TITLE
BUG: Respond to closing RMS

### DIFF
--- a/frontend/src/components/RmsExpireNotification.tsx
+++ b/frontend/src/components/RmsExpireNotification.tsx
@@ -1,0 +1,190 @@
+import { Dialog } from "@equinor/eds-core-react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useRef, useState } from "react";
+
+import {
+  rmsDeleteRmsProjectMutation,
+  rmsGetZonesOptions,
+  sessionGetSessionOptions,
+  sessionGetSessionQueryKey,
+} from "#client/@tanstack/react-query.gen";
+import { GeneralButton } from "#components/form/button";
+import { sessionRmsExpireNotificationThreshold } from "#config";
+import { useProject } from "#services/project";
+import { GenericDialog, PageText } from "#styles/common";
+
+function getSecondsUntilRmsExpiry(rmsExpiresAt?: string | null) {
+  return rmsExpiresAt
+    ? Math.max(0, Math.ceil((Date.parse(rmsExpiresAt) - Date.now()) / 1000))
+    : Number.POSITIVE_INFINITY;
+}
+
+export function RmsExpireNotification() {
+  const project = useProject();
+
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const isCheckingThreshold = useRef(false);
+  const [timeUntilExpire, setTimeUntilExpire] = useState<number>(
+    Number.POSITIVE_INFINITY,
+  );
+  const rmsExpiresAt = project.rmsExpiresAt;
+  const isExpired = !rmsExpiresAt;
+
+  const queryClient = useQueryClient();
+
+  const rmsRefreshMutation = useMutation({
+    mutationFn: async () => {
+      // Invalidate an rms query to trigger rms session extension.
+      await queryClient.fetchQuery({
+        ...rmsGetZonesOptions(),
+        staleTime: 0,
+      });
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: sessionGetSessionQueryKey(),
+      });
+      setIsDialogOpen(false);
+    },
+    meta: {
+      errorPrefix: "Error refreshing RMS access",
+    },
+  });
+
+  const rmsCloseMutation = useMutation({
+    ...rmsDeleteRmsProjectMutation(),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: sessionGetSessionQueryKey(),
+      });
+      setIsDialogOpen(false);
+    },
+    meta: {
+      errorPrefix: "Error closing the RMS project",
+    },
+  });
+
+  useEffect(() => {
+    const initialTimeLeft = getSecondsUntilRmsExpiry(rmsExpiresAt);
+    setTimeUntilExpire(initialTimeLeft);
+
+    if (!Number.isFinite(initialTimeLeft) || initialTimeLeft <= 0) {
+      return;
+    }
+
+    const interval = setInterval(() => {
+      setTimeUntilExpire((currentTimeLeft) => {
+        if (!Number.isFinite(currentTimeLeft) || currentTimeLeft <= 0) {
+          return currentTimeLeft;
+        }
+
+        return currentTimeLeft - 1;
+      });
+    }, 1000);
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, [rmsExpiresAt]);
+
+  useEffect(() => {
+    if (timeUntilExpire === 0) {
+      void queryClient.invalidateQueries({
+        queryKey: sessionGetSessionQueryKey(),
+      });
+    } else if (
+      !isExpired &&
+      !isDialogOpen &&
+      timeUntilExpire <= sessionRmsExpireNotificationThreshold
+    ) {
+      if (isCheckingThreshold.current) {
+        return;
+      }
+
+      isCheckingThreshold.current = true;
+
+      void queryClient
+        .fetchQuery({
+          ...sessionGetSessionOptions(),
+          staleTime: 0,
+        })
+        .then((freshSession) => {
+          const freshTimeUntilExpire = getSecondsUntilRmsExpiry(
+            freshSession.rms_expires_at,
+          );
+
+          setTimeUntilExpire(freshTimeUntilExpire);
+
+          setIsDialogOpen(
+            freshTimeUntilExpire <= sessionRmsExpireNotificationThreshold,
+          );
+        })
+        .finally(() => {
+          isCheckingThreshold.current = false;
+        });
+    }
+  }, [queryClient, timeUntilExpire, isDialogOpen, isExpired]);
+
+  const onRmsAccessRefresh = () => {
+    rmsRefreshMutation.mutate();
+  };
+
+  const onRmsAccessRelease = () => {
+    rmsCloseMutation.mutate({});
+  };
+
+  return (
+    <GenericDialog open={isDialogOpen} $width="35em">
+      <Dialog.Header>
+        {isExpired ? "RMS access expired" : "RMS access is about to expire"}
+      </Dialog.Header>
+
+      <Dialog.Content>
+        {isExpired ? (
+          <PageText $marginBottom="0">
+            Your RMS access has expired. The RMS project can be reopened for
+            access from the RMS page.
+          </PageText>
+        ) : (
+          <>
+            <PageText>
+              Your RMS access will expire in <b>{timeUntilExpire}</b> seconds.
+            </PageText>
+
+            <PageText $marginBottom="0">
+              Do you want to continue accessing data from this RMS project?
+            </PageText>
+          </>
+        )}
+      </Dialog.Content>
+
+      <Dialog.Actions>
+        {isExpired ? (
+          <GeneralButton
+            label="Close"
+            onClick={() => {
+              setIsDialogOpen(false);
+            }}
+          />
+        ) : (
+          <>
+            <GeneralButton
+              label="Continue RMS access"
+              isPending={rmsRefreshMutation.isPending}
+              disabled={rmsCloseMutation.isPending}
+              onClick={onRmsAccessRefresh}
+            />
+
+            <GeneralButton
+              label="Close RMS access"
+              variant="outlined"
+              isPending={rmsCloseMutation.isPending}
+              disabled={rmsRefreshMutation.isPending}
+              onClick={onRmsAccessRelease}
+            />
+          </>
+        )}
+      </Dialog.Actions>
+    </GenericDialog>
+  );
+}

--- a/frontend/src/components/project/overview/ProjectSelector.tsx
+++ b/frontend/src/components/project/overview/ProjectSelector.tsx
@@ -24,6 +24,7 @@ import {
   projectGetRmsProjectsQueryKey,
   projectPostInitProjectMutation,
   projectPostProjectMutation,
+  sessionGetSessionQueryKey,
   userGetUserOptions,
   userGetUserQueryKey,
 } from "#client/@tanstack/react-query.gen";
@@ -48,10 +49,6 @@ import {
   queryKeyProjectGetCacheDiff,
   queryKeyProjectGetCacheRevision,
 } from "#utils/query";
-import {
-  removeStorageItem,
-  STORAGENAME_RMS_PROJECT_OPEN,
-} from "#utils/storage";
 
 const { useAppForm: useAppFormProjectSelectorForm } = createFormHook({
   fieldComponents: {
@@ -136,7 +133,9 @@ function ProjectSelectorForm({
       void queryClient.invalidateQueries({
         queryKey: userGetUserQueryKey(),
       });
-      removeStorageItem(sessionStorage, STORAGENAME_RMS_PROJECT_OPEN);
+      void queryClient.invalidateQueries({
+        queryKey: sessionGetSessionQueryKey(),
+      });
     },
     meta: {
       preventDefaultErrorHandling: codes,

--- a/frontend/src/components/project/rms/Overview.tsx
+++ b/frontend/src/components/project/rms/Overview.tsx
@@ -1,7 +1,7 @@
 import { Dialog } from "@equinor/eds-core-react";
 import { createFormHook } from "@tanstack/react-form";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { type Dispatch, type SetStateAction, useEffect, useState } from "react";
+import { useState } from "react";
 import { toast } from "react-toastify";
 
 import type { RmsProject } from "#client";
@@ -15,6 +15,7 @@ import {
   rmsGetHorizonsQueryKey,
   rmsGetZonesQueryKey,
   rmsPostRmsProjectMutation,
+  sessionGetSessionQueryKey,
 } from "#client/@tanstack/react-query.gen";
 import {
   CancelButton,
@@ -38,11 +39,6 @@ import {
 } from "#utils/api";
 import { fieldContext, formContext } from "#utils/form";
 import { getRmsProjectName } from "#utils/model";
-import {
-  getStorageItem,
-  STORAGENAME_RMS_PROJECT_OPEN,
-  setStorageItem,
-} from "#utils/storage";
 import { isVersionLessThan } from "#utils/string";
 import { Stratigraphy } from "./Stratigraphy";
 
@@ -237,12 +233,10 @@ function RmsInfo({ rmsData }: { rmsData: RmsProject }) {
 function RmsProjectActions({
   rmsData,
   projectReadOnly: projectIsReadOnly,
-  setIsRmsProjectOpen,
   isRmsProjectOpen,
 }: {
   rmsData: RmsProject | null | undefined;
   projectReadOnly: boolean | undefined;
-  setIsRmsProjectOpen: Dispatch<SetStateAction<boolean>>;
   isRmsProjectOpen: boolean;
 }) {
   const queryClient = useQueryClient();
@@ -256,7 +250,9 @@ function RmsProjectActions({
   const projectOpenMutation = useMutation({
     ...rmsPostRmsProjectMutation(),
     onSuccess: () => {
-      setIsRmsProjectOpen(true);
+      void queryClient.invalidateQueries({
+        queryKey: sessionGetSessionQueryKey(),
+      });
       void queryClient.invalidateQueries({
         queryKey: rmsGetHorizonsQueryKey(),
       });
@@ -265,8 +261,6 @@ function RmsProjectActions({
       });
     },
     onError: (error, variables) => {
-      setIsRmsProjectOpen(false);
-
       if (error.response?.status === HTTP_STATUS_422_UNPROCESSABLE_CONTENT) {
         const message = (error.response.data as { detail?: string }).detail;
 
@@ -294,7 +288,9 @@ function RmsProjectActions({
   const projectCloseMutation = useMutation({
     ...rmsDeleteRmsProjectMutation(),
     onSuccess: () => {
-      setIsRmsProjectOpen(false);
+      void queryClient.invalidateQueries({
+        queryKey: sessionGetSessionQueryKey(),
+      });
     },
     meta: {
       errorPrefix: "Error closing the RMS project",
@@ -355,7 +351,7 @@ function RmsProjectActions({
 
             {isRmsProjectOpen && !projectOpenMutation.isPending && (
               <GeneralButton
-                label="Close RMS project for access"
+                label="Close RMS access"
                 variant="outlined"
                 isPending={projectCloseMutation.isPending}
                 onClick={() => {
@@ -379,22 +375,12 @@ function RmsProjectActions({
 export function Overview({
   rmsData,
   projectReadOnly,
+  isRmsProjectOpen,
 }: {
   rmsData: RmsProject | null | undefined;
   projectReadOnly: boolean;
+  isRmsProjectOpen: boolean;
 }) {
-  const [isRmsProjectOpen, setIsRmsProjectOpen] = useState(
-    getStorageItem(sessionStorage, STORAGENAME_RMS_PROJECT_OPEN, "boolean"),
-  );
-
-  useEffect(() => {
-    setStorageItem(
-      sessionStorage,
-      STORAGENAME_RMS_PROJECT_OPEN,
-      isRmsProjectOpen,
-    );
-  }, [isRmsProjectOpen]);
-
   return (
     <>
       <PageSectionWidthConstrained>
@@ -412,7 +398,6 @@ export function Overview({
         <RmsProjectActions
           rmsData={rmsData}
           projectReadOnly={projectReadOnly}
-          setIsRmsProjectOpen={setIsRmsProjectOpen}
           isRmsProjectOpen={isRmsProjectOpen}
         />
 

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -13,6 +13,8 @@ export const ssoScopes = [
   "691a29c5-8199-4e87-80a2-16bd71e831cd/user_impersonation", // SMDA
 ];
 
+export const sessionRmsExpireNotificationThreshold = 120; // 2 minutes
+
 export const projectLockStatusRefetchInterval = 60; // 1 minute
 
 export const projectLockExpireNotificationThreshold = 120; // 2 minutes

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -14,6 +14,7 @@ import { Loading, QueryErrorBoundary } from "#components/common";
 import { Header } from "#components/Header";
 import { LockExpireNotification } from "#components/LockExpireNotification";
 import { ProjectRecoveryNotification } from "#components/ProjectRecoveryNotification";
+import { RmsExpireNotification } from "#components/RmsExpireNotification";
 import { Sidebar } from "#components/Sidebar";
 import type { RouterContext } from "#main";
 import { PageContainer } from "#styles/common";
@@ -117,6 +118,7 @@ function RootComponent() {
       <ToastContainer theme="colored" />
       <ProjectRecoveryNotification />
       <LockExpireNotification />
+      <RmsExpireNotification />
 
       <AppContainer>
         <div className="header">

--- a/frontend/src/routes/project/rms.tsx
+++ b/frontend/src/routes/project/rms.tsx
@@ -22,6 +22,7 @@ function Content() {
     <Overview
       rmsData={project.data.config.rms}
       projectReadOnly={!(project.lockStatus?.is_lock_acquired ?? false)}
+      isRmsProjectOpen={!!project.rmsExpiresAt}
     />
   ) : (
     <PageSectionWidthConstrained>

--- a/frontend/src/services/project.ts
+++ b/frontend/src/services/project.ts
@@ -17,6 +17,7 @@ import {
 import {
   projectGetLockStatusQueryKey,
   projectGetProjectQueryKey,
+  sessionGetSessionOptions,
 } from "#client/@tanstack/react-query.gen";
 import type { LockStatus, ProjectGetMappingsData } from "#client/types.gen";
 import { projectLockStatusRefetchInterval } from "#config";
@@ -29,7 +30,10 @@ import type { QueryServiceBase } from "#utils/query";
 
 export type MappingsPathOptions = ProjectGetMappingsData["path"];
 
-type GetProject = QueryServiceBase<FmuProject> & { lockStatus?: LockStatus };
+type GetProject = QueryServiceBase<FmuProject> & {
+  lockStatus?: LockStatus;
+  rmsExpiresAt?: string | null;
+};
 
 type MappingsPathsKeys = "stratigraphyRms";
 
@@ -125,8 +129,16 @@ export function useProject(options?: Options<ProjectGetProjectData>) {
     enabled: project.status && project.data !== undefined,
   });
 
+  const { data: sessionData } = useQuery({
+    ...sessionGetSessionOptions(),
+    enabled: project.status && project.data !== undefined,
+  });
+
+  const rmsExpiresAt = sessionData?.rms_expires_at;
+
   return {
     ...project,
     lockStatus,
+    rmsExpiresAt,
   } as GetProject;
 }

--- a/frontend/src/utils/storage.ts
+++ b/frontend/src/utils/storage.ts
@@ -2,7 +2,6 @@ export const STORAGENAME_API_TOKEN = "apiToken";
 export const STORAGENAME_MASTERDATA_EDIT_MODE = "masterdataEditMode";
 export const STORAGENAME_PAGESECTION_NOTWIDTHCONSTRAINED_BASE =
   "pageSectionNotWidthConstrained";
-export const STORAGENAME_RMS_PROJECT_OPEN = "rmsProjectOpen";
 export const STORAGENAME_STRATIGRAPHY_EDIT_MODE = "stratigraphyEditMode";
 
 export function getStorageItem(storage: Storage, name: string): string | null;


### PR DESCRIPTION
Resolves #341
Resolves #200 

PR to start using the `sessionResponse` to read the rms expiry time. This removes the need for setting rms open status in the session storage, and enables the GUI to respond to an expired rms session.

When RMS is expired 

- a dialog similar to the LockExpiryNotification is shown
- the buttons are changed from `Load/Close RMS project` to `Access RMS project` again
- opening the stratigraphy edit dialog is disabled.


## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
