### PR TITLE
ENH: Create GUI session before loading project state

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -25,6 +25,7 @@ import { LockIcon } from "#components/LockStatus";
 import { useProject } from "#services/project";
 import { useTaskList } from "#services/tasks";
 import { GenericDialog, PageText } from "#styles/common";
+import { HTTP_STATUS_422_UNPROCESSABLE_CONTENT } from "#utils/api";
 import { AppMenu } from "./AppMenu";
 import {
   FmuLogo,
@@ -105,6 +106,8 @@ function ProjectInfo() {
             value={project.data.config.model?.revision}
           />
         </>
+      ) : project.errorStatus === HTTP_STATUS_422_UNPROCESSABLE_CONTENT ? (
+        "Project configuration is invalid"
       ) : (
         "No project selected"
       )}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -31,9 +31,11 @@ import ReactDOM from "react-dom/client";
 
 import type { Options, SessionPostSessionData, SessionResponse } from "#client";
 import {
+  projectGetProjectQueryKey,
   sessionPatchAccessTokenMutation,
   sessionPostSessionMutation,
   smdaGetHealthQueryKey,
+  userGetUserQueryKey,
 } from "#client/@tanstack/react-query.gen";
 import { client } from "#client/client.gen";
 import { msalConfig, ssoScopes } from "#config";
@@ -57,6 +59,8 @@ export interface RouterContext {
   selectProjectInvalidAttempt: number;
   setSelectProjectInvalidAttempt: Dispatch<SetStateAction<number>>;
   hasResponseInterceptor: boolean;
+  sessionReady: boolean;
+  sessionCreationFailed: boolean;
   accessToken: string;
   createSessionMutateAsync: UseMutateAsyncFunction<
     SessionResponse,
@@ -162,6 +166,8 @@ const router = createRouter({
       SetStateAction<number>
     >,
     hasResponseInterceptor: false,
+    sessionReady: false,
+    sessionCreationFailed: false,
     accessToken: undefined as unknown as string,
     createSessionMutateAsync: undefined as unknown as UseMutateAsyncFunction<
       SessionResponse,
@@ -187,9 +193,9 @@ export function App() {
   const [hasResponseInterceptor, setHasResponseInterceptor] = useState(false);
   const [accessToken, setAccessToken] = useState("");
   const [requestSessionCreation, setRequestSessionCreation] = useState(false);
-  const [sessionCreatedAt, setSessionCreatedAt] = useState<
-    number | undefined
-  >();
+  const [isCreatingSession, setIsCreatingSession] = useState(false);
+  const [sessionReady, setSessionReady] = useState(false);
+  const [sessionCreationFailed, setSessionCreationFailed] = useState(false);
   const [requestAcquireSsoAccessToken, setRequestAcquireSsoAccessToken] =
     useState(false);
   const acquireAndPatchSsoAccessTokenPromise = useRef<
@@ -279,30 +285,68 @@ export function App() {
   }, [acquireAndPatchSsoAccessToken, apiToken, apiTokenStatus.valid]);
 
   useEffect(() => {
+    if (!isApiTokenNonEmpty(apiToken)) {
+      setSessionReady(false);
+      setSessionCreationFailed(false);
+
+      return;
+    }
+
+    if (
+      hasResponseInterceptor &&
+      !sessionReady &&
+      !sessionCreationFailed &&
+      !isCreatingSession &&
+      !requestSessionCreation
+    ) {
+      setRequestSessionCreation(true);
+    }
+  }, [
+    apiToken,
+    hasResponseInterceptor,
+    isCreatingSession,
+    requestSessionCreation,
+    sessionCreationFailed,
+    sessionReady,
+  ]);
+
+  useEffect(() => {
     async function callCreateSessionAsync() {
       await createSessionAsync(createSessionMutateAsync, apiToken);
     }
 
-    if (requestSessionCreation) {
-      if (
-        sessionCreatedAt === undefined ||
-        Date.now() - sessionCreatedAt > 10_000
-      ) {
-        setSessionCreatedAt(Date.now());
-        void callCreateSessionAsync();
-        if (accessToken !== "") {
-          handleAddSsoAccessToken(patchAccessTokenMutate, accessToken);
-        }
-      }
+    if (requestSessionCreation && !isCreatingSession) {
+      setIsCreatingSession(true);
+      setSessionCreationFailed(false);
+      void callCreateSessionAsync()
+        .then(() => {
+          setSessionReady(true);
+          void queryClient.invalidateQueries({
+            queryKey: userGetUserQueryKey(),
+          });
+          void queryClient.invalidateQueries({
+            queryKey: projectGetProjectQueryKey(),
+          });
+          if (accessToken !== "") {
+            handleAddSsoAccessToken(patchAccessTokenMutate, accessToken);
+          }
+        })
+        .catch(() => {
+          setSessionReady(false);
+          setSessionCreationFailed(true);
+        })
+        .finally(() => {
+          setIsCreatingSession(false);
+        });
       setRequestSessionCreation(false);
     }
   }, [
     accessToken,
     apiToken,
     createSessionMutateAsync,
+    isCreatingSession,
     patchAccessTokenMutate,
     requestSessionCreation,
-    sessionCreatedAt,
   ]);
 
   useEffect(() => {
@@ -315,7 +359,13 @@ export function App() {
   // biome-ignore lint/correctness/useExhaustiveDependencies: Invalidate router context when some of the content changes
   useEffect(() => {
     void router.invalidate();
-  }, [hasResponseInterceptor, accessToken, selectProjectInvalidAttempt]);
+  }, [
+    hasResponseInterceptor,
+    sessionReady,
+    sessionCreationFailed,
+    accessToken,
+    selectProjectInvalidAttempt,
+  ]);
 
   useEffect(() => {
     const id = msalInstance.addEventCallback(
@@ -357,6 +407,8 @@ export function App() {
         selectProjectInvalidAttempt,
         setSelectProjectInvalidAttempt,
         hasResponseInterceptor,
+        sessionReady,
+        sessionCreationFailed,
         accessToken,
         createSessionMutateAsync,
         setRequestAcquireSsoAccessToken,

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -10,7 +10,7 @@ import { useEffect } from "react";
 import { ToastContainer } from "react-toastify";
 
 import { userGetUserOptions } from "#client/@tanstack/react-query.gen";
-import { QueryErrorBoundary } from "#components/common";
+import { Loading, QueryErrorBoundary } from "#components/common";
 import { Header } from "#components/Header";
 import { LockExpireNotification } from "#components/LockExpireNotification";
 import { ProjectRecoveryNotification } from "#components/ProjectRecoveryNotification";
@@ -36,7 +36,7 @@ export const Route = createRootRouteWithContext<RouterContext>()({
     }
     context.setApiTokenStatus(apiTokenStatus);
 
-    if (context.hasResponseInterceptor) {
+    if (context.hasResponseInterceptor && context.sessionReady) {
       await context.queryClient
         .fetchQuery({
           ...userGetUserOptions(),
@@ -71,7 +71,8 @@ function StandardErrorComponent(error: Error) {
 }
 
 function RootComponent() {
-  const { apiTokenStatus } = Route.useRouteContext();
+  const { apiTokenStatus, sessionReady, sessionCreationFailed } =
+    Route.useRouteContext();
 
   if (!apiTokenStatus.present || !apiTokenStatus.valid) {
     return (
@@ -80,6 +81,30 @@ function RootComponent() {
           {!apiTokenStatus.present ? "Missing" : "Invalid"} token, please close
           browser tab and open URL again
         </div>
+        <TanStackRouterDevtools />
+        <ReactQueryDevtools />
+      </>
+    );
+  }
+
+  if (sessionCreationFailed) {
+    return (
+      <>
+        <GlobalStyle />
+        <ToastContainer theme="colored" />
+        <div>Unable to create a session.</div>
+        <TanStackRouterDevtools />
+        <ReactQueryDevtools />
+      </>
+    );
+  }
+
+  if (!sessionReady) {
+    return (
+      <>
+        <GlobalStyle />
+        <ToastContainer theme="colored" />
+        <Loading />
         <TanStackRouterDevtools />
         <ReactQueryDevtools />
       </>

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -11,6 +11,7 @@ import {
   PageSectionSpacer,
   PageText,
 } from "#styles/common";
+import { HTTP_STATUS_422_UNPROCESSABLE_CONTENT } from "#utils/api";
 import { displayDateTime } from "#utils/datetime";
 
 export const Route = createFileRoute("/")({
@@ -78,7 +79,11 @@ function RouteComponent() {
         </>
       ) : (
         <>
-          <PageText>No project selected.</PageText>
+          <PageText>
+            {project.errorStatus === HTTP_STATUS_422_UNPROCESSABLE_CONTENT
+              ? "Project configuration is invalid."
+              : "No project selected."}
+          </PageText>
 
           <ProjectSelector />
         </>

--- a/frontend/src/routes/project/index.tsx
+++ b/frontend/src/routes/project/index.tsx
@@ -15,6 +15,7 @@ import {
   PageSectionSpacer,
   PageText,
 } from "#styles/common";
+import { HTTP_STATUS_422_UNPROCESSABLE_CONTENT } from "#utils/api";
 import { displayDateTime } from "#utils/datetime";
 
 export const Route = createFileRoute("/project/")({
@@ -67,9 +68,17 @@ function ProjectInfo({
   );
 }
 
-function ProjectNotFound({ text }: { text: string }) {
+function ProjectNotFound({
+  text,
+  isInvalidProjectConfig,
+}: {
+  text: string;
+  isInvalidProjectConfig: boolean;
+}) {
   const hasText = text !== "";
-  const lead = `No project selected${hasText ? ":" : "."}`;
+  const lead = isInvalidProjectConfig
+    ? `Project configuration is invalid${hasText ? ":" : "."}`
+    : `No project selected${hasText ? ":" : "."}`;
 
   return (
     <>
@@ -83,6 +92,8 @@ function ProjectNotFound({ text }: { text: string }) {
 function Content() {
   const project = useProject();
   const projectReadOnly = !(project.lockStatus?.is_lock_acquired ?? false);
+  const isInvalidProjectConfig =
+    project.errorStatus === HTTP_STATUS_422_UNPROCESSABLE_CONTENT;
 
   return (
     <>
@@ -110,7 +121,10 @@ function Content() {
         </>
       ) : (
         <>
-          <ProjectNotFound text={project.text ?? ""} />
+          <ProjectNotFound
+            text={project.text ?? ""}
+            isInvalidProjectConfig={isInvalidProjectConfig}
+          />
 
           <ProjectSelector />
         </>

--- a/frontend/src/services/project.ts
+++ b/frontend/src/services/project.ts
@@ -20,7 +20,11 @@ import {
 } from "#client/@tanstack/react-query.gen";
 import type { LockStatus, ProjectGetMappingsData } from "#client/types.gen";
 import { projectLockStatusRefetchInterval } from "#config";
-import { HTTP_STATUS_401_UNAUTHORIZED } from "#utils/api";
+import {
+  HTTP_STATUS_401_UNAUTHORIZED,
+  HTTP_STATUS_404_NOT_FOUND,
+  HTTP_STATUS_422_UNPROCESSABLE_CONTENT,
+} from "#utils/api";
 import type { QueryServiceBase } from "#utils/query";
 
 export type MappingsPathOptions = ProjectGetMappingsData["path"];
@@ -50,25 +54,32 @@ export function useProject(options?: Options<ProjectGetProjectData>) {
 
           return { status: true, data } as GetProject;
         } catch (error) {
-          let text = "";
-          let errorStatus: number | undefined;
           if (isAxiosError(error)) {
-            errorStatus = error.status;
+            const errorStatus = error.response?.status;
             // Use normal handling for unauthorized response
-            if (error.status === HTTP_STATUS_401_UNAUTHORIZED) {
-              return Promise.reject(error);
+            if (errorStatus === HTTP_STATUS_401_UNAUTHORIZED) {
+              throw error;
             }
-            if (error.response?.data && "detail" in error.response.data) {
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-              text = String(error.response.data.detail);
+
+            if (
+              errorStatus === HTTP_STATUS_404_NOT_FOUND ||
+              errorStatus === HTTP_STATUS_422_UNPROCESSABLE_CONTENT
+            ) {
+              let text = "";
+              if (error.response?.data && "detail" in error.response.data) {
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+                text = String(error.response.data.detail);
+              }
+
+              return {
+                status: false,
+                text,
+                errorStatus,
+              } as GetProject;
             }
           }
 
-          return {
-            status: false,
-            text,
-            errorStatus,
-          } as GetProject;
+          throw error;
         }
       },
       queryKey: projectGetProjectQueryKey(options),


### PR DESCRIPTION
Resolves #440 

- Added a simple session startup gate: once a token exists and the interceptor is installed, the GUI calls `POST /session/`.
This is how the flow of `fmu settings` command before this PR but with new change in CLI that it waits to open browser after API health is OK.
<img width="793" height="904" alt="2026-06-17_10-11-53 AM" src="https://github.com/user-attachments/assets/ef01e79d-2704-4c85-a2a8-3fcac599557a" />
This is the flow after changes in this PR.
<img width="847" height="783" alt="2026-06-17_10-07-47 AM" src="https://github.com/user-attachments/assets/ce4c31ef-cced-485a-9311-06d86447e46d" />

- Added `sessionReady` to router context and gated the root shell, so Header, Sidebar, notifications, and route content do not mount until session creation succeeds. Before session is ready, the GUI shows `Loading...`.
If session creation fails, the GUI shows a clear error.

- Kept 401 recovery as fallback. If a later API request gets 401, the existing interceptor can still request a new session. After successful session creation, user and project queries are invalidated so they refetch with the new cookie.

- Hardened `useProject()`.

  - 200 still returns project data
  - 404 still becomes “No project selected”
  - 401 still throw, then auth flow handles it, unchanged
  - 422 still supports the recovery flow, but now shows "Project configuration is invalid" text in GUI instead of “No project selected”
  - 500, network/no response, unexpected errors now throw instead of being cached as “No project selected”

- Removed `sessionCreatedAt`. This is used to retry `POST /session/` after 10s. In this case, retrying a failed `POST /session/` would not help based on current API implementation. The failure cases are invalid token, user .fmu permission/filesystem problem, backend bug, API not reachable/network failure. The first three are not helped by automatic retry. The fourth is the only case where retry might help, but the CLI `/health` wait already reduces that at startup. Also, the existing mutation retry helper already does not retry failed session creation.
## Checklist

- [x] Tests added (if not, comment why) - not relevant
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
