### PR TITLE
ENH: Use field UUID for masterdata lookup

### DIFF
--- a/frontend/src/components/project/masterdata/Edit.tsx
+++ b/frontend/src/components/project/masterdata/Edit.tsx
@@ -9,6 +9,7 @@ import {
 import { arrow_back, arrow_forward } from "@equinor/eds-icons";
 import { createFormHook } from "@tanstack/react-form";
 import { useMutation, useQueries, useQueryClient } from "@tanstack/react-query";
+import { isAxiosError } from "axios";
 import {
   type Dispatch,
   type SetStateAction,
@@ -47,6 +48,7 @@ import {
 } from "#styles/common";
 import {
   HTTP_STATUS_422_UNPROCESSABLE_CONTENT,
+  HTTP_STATUS_503_SERVICE_UNAVAILABLE,
   httpValidationErrorToString,
 } from "#utils/api";
 import {
@@ -86,6 +88,7 @@ import type {
   ItemLists,
   MasterdataItemType,
   SelectedItems,
+  SmdaFieldReference,
   SmdaMasterdataResultGrouped,
 } from "./types";
 import {
@@ -236,7 +239,7 @@ function Items({
   operation,
   setSelectedItems,
 }: {
-  fields: Array<string>;
+  fields: Array<SmdaFieldReference>;
   itemType: FieldItemType;
   itemListGrouped: ItemListGrouped<MasterdataItemType>;
   operation: ListOperation;
@@ -246,13 +249,22 @@ function Items({
     Object.keys(itemListGrouped).length === 1 &&
     DUMMYGROUP_NAME in itemListGrouped;
   const groups =
-    !isDummyGroup && fields.length ? fields.sort() : [DUMMYGROUP_NAME];
+    !isDummyGroup && fields.length
+      ? fields
+          .toSorted((a, b) => stringCompare(a.identifier, b.identifier))
+          .map((field) => field.uuid)
+      : [DUMMYGROUP_NAME];
 
   return (
     <>
       {groups.map((group) => (
         <div key={group}>
-          {groups.length > 1 && <PageHeader $variant="h6">{group}</PageHeader>}
+          {groups.length > 1 && (
+            <PageHeader $variant="h6">
+              {fields.find((field) => field.uuid === group)?.identifier ??
+                group}
+            </PageHeader>
+          )}
           <ChipsContainer>
             {group in itemListGrouped && itemListGrouped[group].length > 0 ? (
               itemListGrouped[group]
@@ -312,7 +324,7 @@ export function Edit({
   const [searchDialogOpen, setSearchDialogOpen] = useState(false);
   const [confirmItemsOperationDialogOpen, setConfirmItemsOperationDialogOpen] =
     useState(false);
-  const [smdaFields, setSmdaFields] = useState<Array<string>>([]);
+  const [smdaFields, setSmdaFields] = useState<Array<SmdaFieldReference>>([]);
   const [projectData, setProjectData] = useState<FormMasterdataProject>(
     emptyFormMasterdataProject(),
   );
@@ -353,22 +365,32 @@ export function Edit({
   });
 
   const smdaMasterdata = useQueries({
-    queries: smdaFields.map((field) =>
-      smdaPostMasterdataOptions({ body: [{ identifier: field }] }),
-    ),
+    queries: smdaFields.map((field) => ({
+      ...smdaPostMasterdataOptions({ body: [field] }),
+      retry: (failureCount: number, queryError: Error) =>
+        isAxiosError(queryError) &&
+        (queryError.response === undefined ||
+          queryError.response.status === HTTP_STATUS_503_SERVICE_UNAVAILABLE) &&
+        failureCount < 3,
+    })),
     combine: (results) => ({
       data: results.reduce<SmdaMasterdataResultGrouped>((acc, curr, idx) => {
         if (curr.data !== undefined) {
-          const field =
-            (curr.data.field.length && curr.data.field[0].identifier) ||
-            `index-${String(idx)}`;
-          acc[field] = curr.data;
+          acc[smdaFields[idx].uuid] = curr.data;
         }
 
         return acc;
       }, {}),
       isPending: results.some((result) => result.isPending),
       isSuccess: results.every((result) => result.isSuccess),
+      failedSearchFieldUuids: results.flatMap((result, idx) =>
+        result.isError &&
+        !projectMasterdata.field.some(
+          (field) => field.uuid === smdaFields[idx].uuid,
+        )
+          ? [smdaFields[idx].uuid]
+          : [],
+      ),
     }),
   });
 
@@ -406,6 +428,18 @@ export function Edit({
       closeDialog();
     },
   });
+
+  useEffect(() => {
+    if (!smdaMasterdata.failedSearchFieldUuids.length) {
+      return;
+    }
+
+    setSmdaFields((fields) =>
+      fields.filter(
+        (field) => !smdaMasterdata.failedSearchFieldUuids.includes(field.uuid),
+      ),
+    );
+  }, [smdaMasterdata.failedSearchFieldUuids]);
 
   const handleItemsOperation = useCallback(() => {
     if (selectedItems === undefined || itemsCount(selectedItems.items) === 0) {
@@ -483,8 +517,8 @@ export function Edit({
     if (isOpen) {
       setSmdaFields(
         projectMasterdata.field
-          .map((field) => field.identifier)
-          .sort((a, b) => stringCompare(a, b)),
+          .map(({ identifier, uuid }) => ({ identifier, uuid }))
+          .sort((a, b) => stringCompare(a.identifier, b.identifier)),
       );
     }
   }, [isOpen, projectMasterdata]);
@@ -537,17 +571,17 @@ export function Edit({
     setSearchDialogOpen(false);
   }
 
-  function addFields(fields: Array<string>) {
+  function addFields(fields: Array<SmdaFieldReference>) {
     setSmdaFields((smdaFields) =>
       fields
         .reduce((acc, curr) => {
-          if (!acc.includes(curr)) {
+          if (!acc.some((field) => field.uuid === curr.uuid)) {
             acc.push(curr);
           }
 
           return acc;
         }, smdaFields)
-        .sort((a, b) => stringCompare(a, b)),
+        .sort((a, b) => stringCompare(a.identifier, b.identifier)),
     );
   }
 
@@ -637,9 +671,7 @@ export function Edit({
                           <Label label="Field" htmlFor={field.name} />
                           <ItemsContainer>
                             <Items
-                              fields={field.state.value.map(
-                                (f) => f.identifier,
-                              )}
+                              fields={field.state.value}
                               itemType="field"
                               itemListGrouped={{
                                 [DUMMYGROUP_NAME]: projectData.field,
@@ -681,7 +713,7 @@ export function Edit({
                           <Label label="Country" htmlFor={field.name} />
                           <ItemsContainer>
                             <Items
-                              fields={fieldList.map((f) => f.identifier)}
+                              fields={fieldList}
                               itemListGrouped={{
                                 [DUMMYGROUP_NAME]: projectData.country,
                               }}
@@ -792,7 +824,7 @@ export function Edit({
                           <Label label="Discoveries" htmlFor={field.name} />
                           <ItemsContainer>
                             <Items
-                              fields={fieldList.map((f) => f.identifier)}
+                              fields={fieldList}
                               itemType="discovery"
                               itemListGrouped={projectData.discovery}
                               operation="removal"

--- a/frontend/src/components/project/masterdata/FieldSearch.tsx
+++ b/frontend/src/components/project/masterdata/FieldSearch.tsx
@@ -17,13 +17,14 @@ import {
   SearchFormContainer,
   SearchResultsContainer,
 } from "./FieldSearch.style";
+import type { SmdaFieldReference } from "./types";
 
 function FieldResults({
   data,
   setSelectedFields,
 }: {
   data?: SmdaFieldSearchResult;
-  setSelectedFields: Dispatch<SetStateAction<Array<string>>>;
+  setSelectedFields: Dispatch<SetStateAction<Array<SmdaFieldReference>>>;
 }) {
   const [selectedRows, setSelectedRows] = useState<RowSelectionState>({});
 
@@ -33,18 +34,17 @@ function FieldResults({
   }, [data]);
 
   useEffect(() => {
-    const fieldNames = Object.entries(selectedRows).reduce<Array<string>>(
-      (acc, [uuid]) => {
-        const field = data?.results.find((f) => f.uuid === uuid);
-        if (field && !acc.includes(field.identifier)) {
-          acc.push(field.identifier);
-        }
+    const fields = Object.entries(selectedRows).reduce<
+      Array<SmdaFieldReference>
+    >((acc, [uuid]) => {
+      const field = data?.results.find((f) => f.uuid === uuid);
+      if (field) {
+        acc.push({ identifier: field.identifier, uuid: field.uuid });
+      }
 
-        return acc;
-      },
-      [],
-    );
-    setSelectedFields(fieldNames);
+      return acc;
+    }, []);
+    setSelectedFields(fields);
   }, [selectedRows, data?.results, setSelectedFields]);
 
   const columns: ColumnDef<SmdaFieldUuid>[] = [
@@ -107,11 +107,13 @@ export function FieldSearch({
   closeDialog,
 }: {
   isOpen: boolean;
-  addFields: (fields: Array<string>) => void;
+  addFields: (fields: Array<SmdaFieldReference>) => void;
   closeDialog: () => void;
 }) {
   const [searchValue, setSearchValue] = useState("");
-  const [selectedFields, setSelectedFields] = useState<Array<string>>([]);
+  const [selectedFields, setSelectedFields] = useState<
+    Array<SmdaFieldReference>
+  >([]);
 
   const { data } = useQuery({
     ...smdaPostFieldOptions({ body: { identifier: searchValue } }),

--- a/frontend/src/components/project/masterdata/functions.ts
+++ b/frontend/src/components/project/masterdata/functions.ts
@@ -104,8 +104,8 @@ export function createOptions(
   const defaultCoordinateSystems = Object.entries(smdaMasterdataGrouped).reduce<
     Record<string, SmdaMasterdataCoordinateSystemFields>
   >((acc, fieldData) => {
-    const [field, masterdata] = fieldData;
-    if (projectFields.find((f) => f.identifier === field)) {
+    const [fieldUuid, masterdata] = fieldData;
+    if (projectFields.find((f) => f.uuid === fieldUuid)) {
       const csId = masterdata.field_coordinate_system.uuid;
       if (!(csId in acc)) {
         acc[csId] = {
@@ -143,14 +143,12 @@ export function createOptions(
     // The list of coordinate systems is the same for all SMDA fields
     coordinateSystems:
       fieldCount > 0
-        ? smdaMasterdataGrouped[projectFields[0].identifier].coordinate_systems
+        ? smdaMasterdataGrouped[projectFields[0].uuid].coordinate_systems
         : [],
     coordinateSystemsOptions:
       fieldCount > 0
         ? dcsOptions.concat(
-            smdaMasterdataGrouped[
-              projectFields[0].identifier
-            ].coordinate_systems
+            smdaMasterdataGrouped[projectFields[0].uuid].coordinate_systems
               .filter((cs) => !dcsOptions.some((dcs) => dcs.uuid === cs.uuid))
               .sort((a, b) => stringCompare(a.identifier, b.identifier)),
           )
@@ -158,8 +156,8 @@ export function createOptions(
     stratigraphicColumns: Object.entries(smdaMasterdataGrouped).reduce<
       Array<StratigraphicColumn>
     >((acc, fieldData) => {
-      const [field, masterdata] = fieldData;
-      if (projectFields.find((f) => f.identifier === field)) {
+      const [fieldUuid, masterdata] = fieldData;
+      if (projectFields.find((f) => f.uuid === fieldUuid)) {
         acc.push(...masterdata.stratigraphic_columns);
       }
 
@@ -167,13 +165,15 @@ export function createOptions(
     }, []),
     stratigraphicColumnsOptions: Object.entries(smdaMasterdataGrouped)
       .reduce<Array<StratigraphicColumn>>((acc, fieldData) => {
-        const [field, masterdata] = fieldData;
-        if (projectFields.find((f) => f.identifier === field)) {
+        const [fieldUuid, masterdata] = fieldData;
+        const field = projectFields.find((f) => f.uuid === fieldUuid);
+        if (field) {
           acc.push(
             ...masterdata.stratigraphic_columns.map((value) => ({
               ...value,
               identifier:
-                value.identifier + (fieldCount > 1 ? ` [${field}]` : ""),
+                value.identifier +
+                (fieldCount > 1 ? ` [${field.identifier}]` : ""),
             })),
           );
         }
@@ -191,7 +191,7 @@ export function createItemLists(
   projectDiscoveries: Array<DiscoveryItem>,
 ): [ItemLists, ItemLists, ItemLists] {
   const project = projectFields.reduce<ItemLists>((acc, curr) => {
-    acc.discovery[curr.identifier] = [];
+    acc.discovery[curr.uuid] = [];
 
     return acc;
   }, emptyItemLists());

--- a/frontend/src/components/project/masterdata/types.ts
+++ b/frontend/src/components/project/masterdata/types.ts
@@ -3,12 +3,15 @@ import type {
   CountryItem,
   DiscoveryItem,
   FieldItem,
+  SmdaFieldUuid,
   SmdaMasterdataResult,
   StratigraphicColumn,
 } from "#client";
 import type { ListOperation } from "#utils/form";
 
 export type SmdaMasterdataResultGrouped = Record<string, SmdaMasterdataResult>;
+
+export type SmdaFieldReference = Pick<SmdaFieldUuid, "identifier" | "uuid">;
 
 export type SmdaMasterdataCoordinateSystemFields = {
   coordinateSystem: CoordinateSystem;

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -7,6 +7,7 @@ export const HTTP_STATUS_403_FORBIDDEN = 403;
 export const HTTP_STATUS_404_NOT_FOUND = 404;
 export const HTTP_STATUS_409_CONFLICT = 409;
 export const HTTP_STATUS_422_UNPROCESSABLE_CONTENT = 422;
+export const HTTP_STATUS_503_SERVICE_UNAVAILABLE = 503;
 
 export function httpValidationErrorToString(
   error: AxiosError,


### PR DESCRIPTION
Resolves #409

Use the selected field UUID when retrieving and grouping masterdata so fields with the same identifier remain distinct. Masterdata lookups now retry only transient network and `503` failures, and failed unsaved field searches are removed so the editor remains usable.

## Checklist

- [x] Tests added (if not, comment why) — not relevant
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated 
- [x] Documentation is updated, if necessary 
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
