### PR TITLE
ENH: Add changelog page

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -89,6 +89,7 @@ export function Sidebar() {
       ],
     });
     ProjectSubItems.push({ label: "History", to: "/project/history" });
+    ProjectSubItems.push({ label: "Changelog", to: "/project/changelog" });
   }
 
   return (

--- a/frontend/src/components/home/Changelog.style.ts
+++ b/frontend/src/components/home/Changelog.style.ts
@@ -27,6 +27,69 @@ export const ChangeList = styled.div`
   gap: ${tokens.spacings.comfortable.small};
 `;
 
+export const ChangelogHeader = styled.div`
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: ${tokens.spacings.comfortable.small};
+  margin-bottom: ${tokens.spacings.comfortable.small};
+`;
+
+export const ChangelogGroup = styled.section`
+  & + & {
+    margin-top: ${tokens.spacings.comfortable.large};
+  }
+`;
+
+export const ChangelogGroupHeader = styled.h3`
+  margin: 0 0 ${tokens.spacings.comfortable.small};
+  color: ${tokens.colors.text.static_icons__secondary.hex};
+  font-size: 0.875rem;
+  font-weight: 500;
+`;
+
+export const ChangelogTableContainer = styled.div`
+  height: 70vh;
+  min-height: 30rem;
+  overflow: auto;
+
+  .table-wrapper {
+    height: 100%;
+  }
+
+  table {
+    width: 100% !important;
+  }
+`;
+
+export const ChangelogFilterBar = styled.div`
+  display: flex;
+  align-items: flex-end;
+  gap: ${tokens.spacings.comfortable.small};
+  flex-wrap: wrap;
+  margin-bottom: ${tokens.spacings.comfortable.medium};
+`;
+
+export const ChangelogFilterField = styled.label`
+  display: flex;
+  flex-direction: column;
+  gap: ${tokens.spacings.comfortable.xx_small};
+  min-width: 12rem;
+  color: ${tokens.colors.text.static_icons__default.hex};
+  font-size: 0.875rem;
+  font-weight: 500;
+`;
+
+export const ChangelogFilterSelect = styled.select`
+  min-height: 2.5rem;
+  padding: 0 ${tokens.spacings.comfortable.small};
+  border: 1px solid ${tokens.colors.ui.background__medium.hex};
+  border-radius: ${tokens.shape.corners.borderRadius};
+  background: ${tokens.colors.ui.background__default.hex};
+  color: ${tokens.colors.text.static_icons__default.hex};
+  font: inherit;
+`;
+
 export const ChangeItem = styled.article<{ $changeType: ChangeType }>`
   padding: ${tokens.spacings.comfortable.small} ${tokens.spacings.comfortable.medium};
   border-left: 3px solid ${({ $changeType }) => changeTypeColor($changeType)};
@@ -39,6 +102,7 @@ export const ChangeItemHeader = styled.div`
   align-items: center;
   justify-content: space-between;
   gap: ${tokens.spacings.comfortable.small};
+  flex-wrap: wrap;
 `;
 
 export const ChangeTypeChip = styled(Chip)<{ $changeType: ChangeType }>`
@@ -59,4 +123,70 @@ export const ChangeItemMeta = styled.div`
   margin-top: ${tokens.spacings.comfortable.xx_small};
   color: ${tokens.colors.text.static_icons__secondary.hex};
   font-size: 0.875rem;
+`;
+
+export const ChangeItemField = styled(ChangeItemMeta)`
+  overflow-wrap: anywhere;
+`;
+
+export const ChangeDetails = styled.div`
+  margin-top: ${tokens.spacings.comfortable.small};
+  padding: ${tokens.spacings.comfortable.small};
+  border: 1px solid ${tokens.colors.ui.background__medium.hex};
+  border-radius: ${tokens.shape.corners.borderRadius};
+  background: ${tokens.colors.ui.background__default.hex};
+`;
+
+export const ChangeDetailsHeader = styled.div`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: ${tokens.spacings.comfortable.small};
+  margin-bottom: ${tokens.spacings.comfortable.small};
+`;
+
+export const ChangeDetailsSummary = styled.div`
+  margin-bottom: ${tokens.spacings.comfortable.small};
+  color: ${tokens.colors.text.static_icons__secondary.hex};
+`;
+
+export const ChangeDetailsValueGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: ${tokens.spacings.comfortable.small};
+
+  @media (max-width: 48em) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+export const ChangeDetailsValuePanel = styled.div<{
+  $kind: "before" | "after";
+}>`
+  padding: ${tokens.spacings.comfortable.small};
+  border: 1px solid
+    ${({ $kind }) =>
+      $kind === "before"
+        ? tokens.colors.interactive.danger__resting.hex
+        : tokens.colors.interactive.success__resting.hex};
+  border-radius: ${tokens.shape.corners.borderRadius};
+  background: ${({ $kind }) =>
+    $kind === "before"
+      ? tokens.colors.ui.background__danger.hex
+      : tokens.colors.interactive.success__highlight.hex};
+`;
+
+export const ChangeDetailsValueHeader = styled.div`
+  margin-bottom: ${tokens.spacings.comfortable.small};
+  font-weight: 500;
+`;
+
+export const ChangeDetailsContent = styled.pre`
+  margin: 0;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  color: ${tokens.colors.text.static_icons__default.hex};
+  font-size: 0.875rem;
+  line-height: 1.4;
 `;

--- a/frontend/src/components/home/Changelog.tsx
+++ b/frontend/src/components/home/Changelog.tsx
@@ -1,10 +1,19 @@
+import { Button, Dialog, Typography } from "@equinor/eds-core-react";
+import { type ColumnDef, EdsDataGrid } from "@equinor/eds-data-grid-react";
 import { useSuspenseQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
 import { isAxiosError } from "axios";
-import { Suspense } from "react";
+import { type ChangeEvent, Suspense, useState } from "react";
 
 import { projectGetChangelogOptions } from "#client/@tanstack/react-query.gen";
+import type { ChangeInfo, ChangeType } from "#client/types.gen";
 import { Loading, QueryErrorBoundary } from "#components/common";
-import { PageHeader, PageText } from "#styles/common";
+import {
+  GenericDialog,
+  PageContainerNotWidthConstrained,
+  PageHeader,
+  PageText,
+} from "#styles/common";
 import {
   HTTP_STATUS_404_NOT_FOUND,
   HTTP_STATUS_422_UNPROCESSABLE_CONTENT,
@@ -12,15 +21,78 @@ import {
 import { displayDateTime } from "#utils/datetime";
 import {
   ChangeDescription,
+  ChangeDetails,
+  ChangeDetailsContent,
+  ChangeDetailsHeader,
+  ChangeDetailsSummary,
+  ChangeDetailsValueGrid,
+  ChangeDetailsValueHeader,
+  ChangeDetailsValuePanel,
   ChangeItem,
+  ChangeItemField,
   ChangeItemHeader,
   ChangeItemMeta,
   ChangeList,
+  ChangelogFilterBar,
+  ChangelogFilterField,
+  ChangelogFilterSelect,
+  ChangelogHeader,
+  ChangelogTableContainer,
   ChangeTypeChip,
 } from "./Changelog.style";
-import { FILE_LABELS, formatEntryDescription, getTypeLabel } from "./utils";
+import {
+  FILE_LABELS,
+  formatChangeDetails,
+  formatChangedField,
+  formatEntryDescription,
+  getTypeLabel,
+  parseChangeDetails,
+} from "./utils";
 
-function Content() {
+type ChangelogContentProps = {
+  full?: boolean;
+};
+
+type EntryLimit = "all" | "10" | "25" | "50" | "100";
+
+type ChangelogFilters = {
+  changeType: "all" | ChangeType;
+  entryLimit: EntryLimit;
+};
+
+const RECENT_CHANGE_COUNT = 5;
+
+const CHANGE_TYPE_OPTIONS: ("all" | ChangeType)[] = [
+  "all",
+  "init",
+  "add",
+  "update",
+  "remove",
+  "reset",
+  "restore",
+  "merge",
+  "copy",
+];
+
+const ENTRY_LIMIT_OPTIONS: EntryLimit[] = ["all", "10", "25", "50", "100"];
+
+const DEFAULT_CHANGELOG_FILTERS: ChangelogFilters = {
+  changeType: "all",
+  entryLimit: "all",
+};
+
+function getEntryKey(entry: ChangeInfo, index: number) {
+  return [
+    entry.timestamp ?? "no-time",
+    entry.user,
+    entry.file,
+    entry.key || entry.path || "no-field",
+    entry.change_type,
+    index,
+  ].join(":");
+}
+
+function useChangelogEntries() {
   const { data } = useSuspenseQuery({
     ...projectGetChangelogOptions(),
     meta: {
@@ -43,54 +115,345 @@ function Content() {
       ) && failureCount < 3,
   });
 
-  if (data.length === 0) {
-    return <PageText>No changelog entries yet.</PageText>;
+  return [...data].sort((a, b) =>
+    (b.timestamp ?? "").localeCompare(a.timestamp ?? ""),
+  );
+}
+
+function getChangeTypeOptionLabel(changeType: "all" | ChangeType) {
+  if (changeType === "all") {
+    return "All change types";
   }
 
-  const latestChanges = [...data]
-    .sort((a, b) => (b.timestamp ?? "").localeCompare(a.timestamp ?? ""))
-    .slice(0, 5);
+  return getTypeLabel(changeType);
+}
+
+function filterChangelogEntries(
+  entries: ChangeInfo[],
+  filters: ChangelogFilters,
+) {
+  const changeTypeFilteredEntries =
+    filters.changeType === "all"
+      ? entries
+      : entries.filter((entry) => entry.change_type === filters.changeType);
+
+  if (filters.entryLimit === "all") {
+    return changeTypeFilteredEntries;
+  }
+
+  return changeTypeFilteredEntries.slice(0, Number(filters.entryLimit));
+}
+
+function ChangelogEntry({
+  entry,
+  showField,
+}: {
+  entry: ChangeInfo;
+  showField: boolean;
+}) {
+  return (
+    <ChangeItem $changeType={entry.change_type}>
+      <ChangeItemHeader>
+        <ChangeDescription>
+          {formatEntryDescription(entry)}
+          {entry.change_type !== "init" && (
+            <>
+              {" "}
+              <span style={{ fontWeight: "normal" }}>in</span>{" "}
+              {FILE_LABELS[entry.file] ?? entry.file}
+            </>
+          )}
+        </ChangeDescription>
+        <ChangeTypeChip $changeType={entry.change_type}>
+          {getTypeLabel(entry.change_type)}
+        </ChangeTypeChip>
+      </ChangeItemHeader>
+      {showField && entry.change_type !== "init" && (
+        <ChangeItemField>
+          Changed field: {formatChangedField(entry)}
+        </ChangeItemField>
+      )}
+      <ChangeItemMeta>
+        {entry.timestamp ? displayDateTime(entry.timestamp) : "(unknown date)"}{" "}
+        by {entry.user}
+      </ChangeItemMeta>
+    </ChangeItem>
+  );
+}
+
+function ChangeDetailsDialog({
+  entry,
+  onClose,
+}: {
+  entry?: ChangeInfo;
+  onClose: () => void;
+}) {
+  const fieldPath = entry ? entry.key || entry.path : undefined;
+  const details = entry
+    ? parseChangeDetails(entry.change, fieldPath)
+    : undefined;
+  const hasValueDiff =
+    details?.oldValue !== undefined || details?.newValue !== undefined;
 
   return (
-    <>
-      <PageText>
-        {latestChanges.length === 1
-          ? "Showing the most recent change to this project's settings."
-          : `Showing the ${latestChanges.length} most recent changes to this project's settings.`}
-      </PageText>
+    <GenericDialog open={entry !== undefined} $maxWidth="56em">
+      <Dialog.Header>
+        <Dialog.Title>Changelog details</Dialog.Title>
+      </Dialog.Header>
 
-      <ChangeList>
-        {latestChanges.map((entry) => {
-          return (
-            <ChangeItem
-              key={entry.timestamp ?? "no-time"}
-              $changeType={entry.change_type}
-            >
-              <ChangeItemHeader>
-                <ChangeDescription>
+      <Dialog.CustomContent>
+        {entry && (
+          <ChangeDetails>
+            <ChangeDetailsHeader>
+              <PageText $marginBottom="0">
+                <span className="emphasis">
                   {formatEntryDescription(entry)}
-                  {entry.change_type !== "init" && (
-                    <>
-                      {" "}
-                      <span style={{ fontWeight: "normal" }}>in</span>{" "}
-                      {FILE_LABELS[entry.file] ?? entry.file}
-                    </>
-                  )}
-                </ChangeDescription>
-                <ChangeTypeChip $changeType={entry.change_type}>
-                  {getTypeLabel(entry.change_type)}
-                </ChangeTypeChip>
-              </ChangeItemHeader>
-              <ChangeItemMeta>
+                </span>
+                {entry.change_type !== "init" && (
+                  <> in {FILE_LABELS[entry.file] ?? entry.file}</>
+                )}
+                <br />
+                Changed field: {formatChangedField(entry)}
+                <br />
                 {entry.timestamp
                   ? displayDateTime(entry.timestamp)
                   : "(unknown date)"}{" "}
                 by {entry.user}
-              </ChangeItemMeta>
-            </ChangeItem>
-          );
-        })}
-      </ChangeList>
+              </PageText>
+              <ChangeTypeChip $changeType={entry.change_type}>
+                {getTypeLabel(entry.change_type)}
+              </ChangeTypeChip>
+            </ChangeDetailsHeader>
+
+            {hasValueDiff ? (
+              <>
+                {details.summary && (
+                  <ChangeDetailsSummary>{details.summary}</ChangeDetailsSummary>
+                )}
+                <ChangeDetailsValueGrid>
+                  <ChangeDetailsValuePanel $kind="before">
+                    <ChangeDetailsValueHeader>
+                      Before change
+                    </ChangeDetailsValueHeader>
+                    <ChangeDetailsContent>
+                      {details.oldValue ?? "(empty)"}
+                    </ChangeDetailsContent>
+                  </ChangeDetailsValuePanel>
+                  <ChangeDetailsValuePanel $kind="after">
+                    <ChangeDetailsValueHeader>
+                      After change
+                    </ChangeDetailsValueHeader>
+                    <ChangeDetailsContent>
+                      {details.newValue ?? "(empty)"}
+                    </ChangeDetailsContent>
+                  </ChangeDetailsValuePanel>
+                </ChangeDetailsValueGrid>
+              </>
+            ) : (
+              <>
+                <ChangeDetailsSummary>
+                  Detailed before and after values were not recorded for this
+                  changelog entry.
+                </ChangeDetailsSummary>
+                <ChangeDetailsContent>
+                  {formatChangeDetails(entry.change, fieldPath)}
+                </ChangeDetailsContent>
+              </>
+            )}
+          </ChangeDetails>
+        )}
+      </Dialog.CustomContent>
+
+      <Dialog.Actions>
+        <Button variant="outlined" onClick={onClose}>
+          Close
+        </Button>
+      </Dialog.Actions>
+    </GenericDialog>
+  );
+}
+
+function FullChangelogTable({ entries }: { entries: ChangeInfo[] }) {
+  const [selectedEntry, setSelectedEntry] = useState<ChangeInfo | undefined>();
+  const columns: ColumnDef<ChangeInfo>[] = [
+    {
+      accessorKey: "timestamp",
+      header: "Date",
+      cell: ({ row }) =>
+        row.original.timestamp
+          ? displayDateTime(row.original.timestamp)
+          : "(unknown date)",
+    },
+    {
+      accessorKey: "change_type",
+      header: "Change type",
+      cell: ({ row }) => getTypeLabel(row.original.change_type),
+    },
+    {
+      id: "description",
+      header: "Change",
+      accessorFn: (entry) => formatEntryDescription(entry),
+    },
+    {
+      accessorKey: "file",
+      header: "File",
+      cell: ({ row }) => FILE_LABELS[row.original.file] ?? row.original.file,
+    },
+    {
+      id: "field",
+      header: "Field",
+      accessorFn: (entry) => formatChangedField(entry),
+    },
+    {
+      accessorKey: "user",
+      header: "User",
+    },
+    {
+      id: "details",
+      header: "Details",
+      cell: ({ row }) => (
+        <Button
+          variant="outlined"
+          onClick={() => {
+            setSelectedEntry(row.original);
+          }}
+        >
+          View details
+        </Button>
+      ),
+    },
+  ];
+
+  return (
+    <>
+      <ChangeDetailsDialog
+        entry={selectedEntry}
+        onClose={() => {
+          setSelectedEntry(undefined);
+        }}
+      />
+
+      <ChangelogTableContainer>
+        <EdsDataGrid
+          stickyHeader
+          rows={entries}
+          columns={columns}
+          getRowId={(row) => getEntryKey(row, entries.indexOf(row))}
+          onRowClick={(row) => {
+            setSelectedEntry(row.original);
+          }}
+        ></EdsDataGrid>
+      </ChangelogTableContainer>
+    </>
+  );
+}
+
+function ChangelogFilterControls({
+  filters,
+  onChange,
+}: {
+  filters: ChangelogFilters;
+  onChange: (filters: ChangelogFilters) => void;
+}) {
+  function handleChange(
+    field: keyof ChangelogFilters,
+    event: ChangeEvent<HTMLSelectElement>,
+  ) {
+    onChange({ ...filters, [field]: event.target.value });
+  }
+
+  return (
+    <ChangelogFilterBar>
+      <ChangelogFilterField>
+        Change type
+        <ChangelogFilterSelect
+          value={filters.changeType}
+          onChange={(event) => {
+            handleChange("changeType", event);
+          }}
+        >
+          {CHANGE_TYPE_OPTIONS.map((changeType) => (
+            <option key={changeType} value={changeType}>
+              {getChangeTypeOptionLabel(changeType)}
+            </option>
+          ))}
+        </ChangelogFilterSelect>
+      </ChangelogFilterField>
+
+      <ChangelogFilterField>
+        Number of entries
+        <ChangelogFilterSelect
+          value={filters.entryLimit}
+          onChange={(event) => {
+            handleChange("entryLimit", event);
+          }}
+        >
+          {ENTRY_LIMIT_OPTIONS.map((entryLimit) => (
+            <option key={entryLimit} value={entryLimit}>
+              {entryLimit === "all" ? "All entries" : entryLimit}
+            </option>
+          ))}
+        </ChangelogFilterSelect>
+      </ChangelogFilterField>
+    </ChangelogFilterBar>
+  );
+}
+
+function Content({ full = false }: ChangelogContentProps) {
+  const allChanges = useChangelogEntries();
+  const [filters, setFilters] = useState<ChangelogFilters>(
+    DEFAULT_CHANGELOG_FILTERS,
+  );
+
+  if (allChanges.length === 0) {
+    return <PageText>No changelog entries yet.</PageText>;
+  }
+
+  const changes = full
+    ? filterChangelogEntries(allChanges, filters)
+    : allChanges.slice(0, RECENT_CHANGE_COUNT);
+
+  return (
+    <>
+      <PageText>
+        {full
+          ? `Showing ${changes.length} of ${allChanges.length} changes to this project's settings.`
+          : changes.length === 1
+            ? "Showing the most recent change to this project's settings."
+            : `Showing the ${changes.length} most recent changes to this project's settings.`}
+      </PageText>
+
+      {full ? (
+        <PageContainerNotWidthConstrained>
+          <ChangelogFilterControls filters={filters} onChange={setFilters} />
+          {changes.length === 0 ? (
+            <PageText>
+              No changelog entries match the selected filters.
+            </PageText>
+          ) : (
+            <FullChangelogTable entries={changes} />
+          )}
+        </PageContainerNotWidthConstrained>
+      ) : (
+        <>
+          <ChangeList>
+            {changes.map((entry, index) => (
+              <ChangelogEntry
+                key={getEntryKey(entry, index)}
+                entry={entry}
+                showField={false}
+              />
+            ))}
+          </ChangeList>
+          {allChanges.length > RECENT_CHANGE_COUNT && (
+            <PageText>
+              <Typography link as={Link} to="/project/changelog">
+                View full changelog
+              </Typography>
+            </PageText>
+          )}
+        </>
+      )}
     </>
   );
 }
@@ -98,7 +461,11 @@ function Content() {
 export function Changelog() {
   return (
     <>
-      <PageHeader $variant="h3">Changelog</PageHeader>
+      <ChangelogHeader>
+        <PageHeader $variant="h3" $marginBottom="0">
+          Changelog
+        </PageHeader>
+      </ChangelogHeader>
 
       <QueryErrorBoundary
         statusCodeHandling={{
@@ -117,5 +484,26 @@ export function Changelog() {
         </Suspense>
       </QueryErrorBoundary>
     </>
+  );
+}
+
+export function FullChangelog() {
+  return (
+    <QueryErrorBoundary
+      statusCodeHandling={{
+        [HTTP_STATUS_404_NOT_FOUND]: {
+          message: "No changelog found for this project.",
+          enableRetry: false,
+        },
+        [HTTP_STATUS_422_UNPROCESSABLE_CONTENT]: {
+          message: "The changelog contains invalid data and cannot be shown.",
+          enableRetry: false,
+        },
+      }}
+    >
+      <Suspense fallback={<Loading />}>
+        <Content full />
+      </Suspense>
+    </QueryErrorBoundary>
   );
 }

--- a/frontend/src/components/home/utils.ts
+++ b/frontend/src/components/home/utils.ts
@@ -115,3 +115,155 @@ export function formatEntryDescription(entry: ChangeInfo): string {
     return formatBriefDescription(entry.change);
   }
 }
+
+export function formatChangedField(entry: ChangeInfo): string {
+  const field = entry.key || entry.path;
+
+  if (!field) {
+    return "Unknown field";
+  }
+
+  return field;
+}
+
+export type ParsedChangeDetails = {
+  raw: string;
+  summary?: string;
+  oldValue?: string;
+  newValue?: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseSerializedValue(value: string): unknown {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    // Some changelog payloads may come from Python-style repr strings.
+  }
+
+  try {
+    return JSON.parse(
+      value
+        .replace(/\bNone\b/g, "null")
+        .replace(/\bTrue\b/g, "true")
+        .replace(/\bFalse\b/g, "false")
+        .replace(/'/g, '"'),
+    ) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+function getValueByPath(value: unknown, pathParts: string[]) {
+  let current = value;
+
+  for (const part of pathParts) {
+    if (!isRecord(current) || !(part in current)) {
+      return undefined;
+    }
+
+    current = current[part];
+  }
+
+  return current;
+}
+
+function getNestedChangedValue(value: unknown, fieldPath: string) {
+  const parts = fieldPath.split(".").filter(Boolean);
+
+  for (let index = 0; index < parts.length; index += 1) {
+    const nestedValue = getValueByPath(value, parts.slice(index));
+    if (nestedValue !== undefined) {
+      return nestedValue;
+    }
+  }
+
+  return undefined;
+}
+
+function formatDetailedValue(value: unknown): string {
+  if (value === undefined || value === null || value === "") {
+    return "(empty)";
+  }
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  return JSON.stringify(value, null, 2);
+}
+
+function formatChangeValue(value: string, fieldPath?: string): string {
+  const parsedValue = parseSerializedValue(value);
+
+  if (parsedValue === undefined || !fieldPath) {
+    return value.trim();
+  }
+
+  const nestedValue = getNestedChangedValue(parsedValue, fieldPath);
+
+  return formatDetailedValue(nestedValue ?? parsedValue);
+}
+
+export function parseChangeDetails(
+  change: string,
+  fieldPath?: string,
+): ParsedChangeDetails {
+  const details = change.trim();
+
+  if (!details) {
+    return { raw: "No detailed change information available." };
+  }
+
+  const oldValueIndex = details.indexOf("Old value:");
+  const newValueIndex = details.indexOf("New value:");
+
+  if (
+    oldValueIndex !== -1 &&
+    newValueIndex !== -1 &&
+    oldValueIndex < newValueIndex
+  ) {
+    return {
+      raw: details,
+      summary: details
+        .slice(0, oldValueIndex)
+        .replace(/\.\s*$/, "")
+        .trim(),
+      oldValue: formatChangeValue(
+        details
+          .slice(oldValueIndex + "Old value:".length, newValueIndex)
+          .replace(/\.\s*$/, "")
+          .trim(),
+        fieldPath,
+      ),
+      newValue: formatChangeValue(
+        details.slice(newValueIndex + "New value:".length).trim(),
+        fieldPath,
+      ),
+    };
+  }
+
+  return { raw: details };
+}
+
+export function formatChangeDetails(
+  change: string,
+  fieldPath?: string,
+): string {
+  const details = parseChangeDetails(change, fieldPath);
+
+  if (details.oldValue !== undefined || details.newValue !== undefined) {
+    return [
+      details.summary,
+      `- ${formatChangeValue(details.oldValue ?? "", fieldPath)}`,
+      `+ ${formatChangeValue(details.newValue ?? "", fieldPath)}`,
+    ]
+      .filter(Boolean)
+      .join("\n");
+  }
+
+  return details.raw;
+}

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as ProjectRmsRouteImport } from "./routes/project/rms";
 import { Route as ProjectMasterdataRouteImport } from "./routes/project/masterdata";
 import { Route as ProjectMappingsRouteImport } from "./routes/project/mappings";
 import { Route as ProjectHistoryRouteImport } from "./routes/project/history";
+import { Route as ProjectChangelogRouteImport } from "./routes/project/changelog";
 import { Route as ProjectRmsIndexRouteImport } from "./routes/project/rms/index";
 import { Route as ProjectMappingsIndexRouteImport } from "./routes/project/mappings/index";
 import { Route as ProjectRmsWellboresRouteImport } from "./routes/project/rms/wellbores";
@@ -66,6 +67,11 @@ const ProjectHistoryRoute = ProjectHistoryRouteImport.update({
   path: "/project/history",
   getParentRoute: () => rootRouteImport,
 } as any);
+const ProjectChangelogRoute = ProjectChangelogRouteImport.update({
+  id: "/project/changelog",
+  path: "/project/changelog",
+  getParentRoute: () => rootRouteImport,
+} as any);
 const ProjectRmsIndexRoute = ProjectRmsIndexRouteImport.update({
   id: "/",
   path: "/",
@@ -111,6 +117,7 @@ const ProjectMappingsOverviewRoute = ProjectMappingsOverviewRouteImport.update({
 
 export interface FileRoutesByFullPath {
   "/": typeof IndexRoute;
+  "/project/changelog": typeof ProjectChangelogRoute;
   "/project/history": typeof ProjectHistoryRoute;
   "/project/mappings": typeof ProjectMappingsRouteWithChildren;
   "/project/masterdata": typeof ProjectMasterdataRoute;
@@ -129,6 +136,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   "/": typeof IndexRoute;
+  "/project/changelog": typeof ProjectChangelogRoute;
   "/project/history": typeof ProjectHistoryRoute;
   "/project/masterdata": typeof ProjectMasterdataRoute;
   "/user/keys": typeof UserKeysRoute;
@@ -146,6 +154,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport;
   "/": typeof IndexRoute;
+  "/project/changelog": typeof ProjectChangelogRoute;
   "/project/history": typeof ProjectHistoryRoute;
   "/project/mappings": typeof ProjectMappingsRouteWithChildren;
   "/project/masterdata": typeof ProjectMasterdataRoute;
@@ -166,6 +175,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath;
   fullPaths:
     | "/"
+    | "/project/changelog"
     | "/project/history"
     | "/project/mappings"
     | "/project/masterdata"
@@ -184,6 +194,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo;
   to:
     | "/"
+    | "/project/changelog"
     | "/project/history"
     | "/project/masterdata"
     | "/user/keys"
@@ -200,6 +211,7 @@ export interface FileRouteTypes {
   id:
     | "__root__"
     | "/"
+    | "/project/changelog"
     | "/project/history"
     | "/project/mappings"
     | "/project/masterdata"
@@ -219,6 +231,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute;
+  ProjectChangelogRoute: typeof ProjectChangelogRoute;
   ProjectHistoryRoute: typeof ProjectHistoryRoute;
   ProjectMappingsRoute: typeof ProjectMappingsRouteWithChildren;
   ProjectMasterdataRoute: typeof ProjectMasterdataRoute;
@@ -284,6 +297,13 @@ declare module "@tanstack/react-router" {
       path: "/project/history";
       fullPath: "/project/history";
       preLoaderRoute: typeof ProjectHistoryRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/project/changelog": {
+      id: "/project/changelog";
+      path: "/project/changelog";
+      fullPath: "/project/changelog";
+      preLoaderRoute: typeof ProjectChangelogRouteImport;
       parentRoute: typeof rootRouteImport;
     };
     "/project/rms/": {
@@ -383,6 +403,7 @@ const ProjectRmsRouteWithChildren = ProjectRmsRoute._addFileChildren(
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  ProjectChangelogRoute: ProjectChangelogRoute,
   ProjectHistoryRoute: ProjectHistoryRoute,
   ProjectMappingsRoute: ProjectMappingsRouteWithChildren,
   ProjectMasterdataRoute: ProjectMasterdataRoute,

--- a/frontend/src/routes/project/changelog.tsx
+++ b/frontend/src/routes/project/changelog.tsx
@@ -1,0 +1,38 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { Suspense } from "react";
+
+import { Loading } from "#components/common";
+import { FullChangelog } from "#components/home/Changelog";
+import { useProject } from "#services/project";
+import { PageHeader, PageText } from "#styles/common";
+
+export const Route = createFileRoute("/project/changelog")({
+  component: RouteComponent,
+});
+
+function Content() {
+  const project = useProject();
+
+  if (!(project.status && project.data !== undefined)) {
+    return <PageText>No project selected.</PageText>;
+  }
+
+  return <FullChangelog />;
+}
+
+function RouteComponent() {
+  return (
+    <>
+      <PageHeader>Changelog</PageHeader>
+
+      <PageText>
+        This page displays the full changelog for the selected project. Use the
+        filters to narrow the list by change type or number of entries.
+      </PageText>
+
+      <Suspense fallback={<Loading />}>
+        <Content />
+      </Suspense>
+    </>
+  );
+}


### PR DESCRIPTION
Resolves #456

This PR adds a dedicated full changelog page for selected projects while keeping the homepage changelog as a compact “recent changes” preview.

Main Changes
- Added a new project route: `changelog.tsx`. 
    - Shows the full changelog for the selected project.
    - Handles the no-project-selected state.
    - Includes a short intro explaining the page and filters.

- Added `Changelog` to the Project sidebar in `Sidebar.tsx`, under `History`.

- Updated `Changelog.tsx`.
    - Homepage changelog still shows only the most recent entries.
    - Adds a link from the homepage preview to the full changelog page.
    - Full changelog now renders as an `EdsDataGrid`.
    - Table supports filtering by `change type` and `number of entries`.
    - Table uses full page width via `PageContainerNotWidthConstrained`.
    - Each row has an outlined `View details` button.
 
- Improved changelog detail rendering in `utils.ts`. 
    - Parses `Old value / New value `changelog payloads.
    - Attempts to extract only the changed nested field using `entry.key / entry.path`.
    - Falls back to the original full value if parsing or path extraction fails.

- Added styling in `Changelog.style.ts`. 
    - Full-width table container.
    - Filter controls.
    - Details dialog layout.
    - Colored before/after panels inspired by the cache diff view.   

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [ ] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [ ] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [ ] Checked the boxes in this checklist ✅
