### PR TITLE
BLD: Update vulnerable packages

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -7,8 +7,9 @@ settings:
 overrides:
   '@babel/core@<=7.29.0': '>=7.29.6 <8'
   ajv@<6.14.0: '>=6.14.0 <7'
-  brace-expansion@<1.1.13: 1.1.13
+  brace-expansion@<1.1.16: '>=1.1.16 <2'
   brace-expansion@>=2.0.0 <2.0.3: '>=2.0.3'
+  brace-expansion@>=3.0.0 <5.0.7: '>=5.0.7 <6'
   defu@<=6.1.4: '>=6.1.5'
   devalue@<=5.6.2: '>=5.6.3'
   diff@>=6.0.0 <8.0.3: '>=8.0.3'
@@ -16,7 +17,7 @@ overrides:
   follow-redirects@<=1.15.11: '>=1.16.0'
   form-data@>=4.0.0 <4.0.6: '>=4.0.6 <5'
   handlebars@<4.7.9: '>=4.7.9'
-  js-yaml@<=4.1.1: '>=4.2.0 <5'
+  js-yaml@>=4.0.0 <4.3.0: '>=4.3.0 <5'
   lodash@>=4.0.0 <=4.17.23: '>=4.18.0'
   minimatch@>=10.0.0 <10.2.3: '>=10.2.3'
   picomatch@<2.3.2: 2.3.2
@@ -1120,11 +1121,11 @@ packages:
   birecord@0.1.1:
     resolution: {integrity: sha512-VUpsf/qykW0heRlC8LooCq28Kxn3mAqKohhDG/49rrsQ1dT1CXyj/pgXS+5BSRzFTR/3DyIBOqQOrGyZOh71Aw==}
 
-  brace-expansion@1.1.13:
-    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   browserslist@4.28.2:
@@ -1529,8 +1530,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -2412,7 +2413,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -2461,7 +2462,7 @@ snapshots:
     dependencies:
       '@jsdevtools/ono': 7.1.3
       '@types/json-schema': 7.0.15
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       lodash: 4.18.1
 
   '@hey-api/openapi-ts@0.66.7(typescript@5.8.3)':
@@ -3014,12 +3015,12 @@ snapshots:
 
   birecord@0.1.1: {}
 
-  brace-expansion@1.1.13:
+  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -3459,7 +3460,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -3512,11 +3513,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.13
+      brace-expansion: 1.1.16
 
   minimist@1.2.8: {}
 

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -6,8 +6,9 @@ minimumReleaseAge: 10080 # age in minutes (7 days)
 overrides:
   '@babel/core@<=7.29.0': '>=7.29.6 <8'
   ajv@<6.14.0: '>=6.14.0 <7'
-  brace-expansion@<1.1.13: 1.1.13
+  brace-expansion@<1.1.16: '>=1.1.16 <2'
   brace-expansion@>=2.0.0 <2.0.3: '>=2.0.3'
+  brace-expansion@>=3.0.0 <5.0.7: '>=5.0.7 <6'
   defu@<=6.1.4: '>=6.1.5'
   devalue@<=5.6.2: '>=5.6.3'
   diff@>=6.0.0 <8.0.3: '>=8.0.3'
@@ -15,7 +16,7 @@ overrides:
   follow-redirects@<=1.15.11: '>=1.16.0'
   form-data@>=4.0.0 <4.0.6: '>=4.0.6 <5'
   handlebars@<4.7.9: '>=4.7.9'
-  js-yaml@<=4.1.1: '>=4.2.0 <5'
+  js-yaml@>=4.0.0 <4.3.0: '>=4.3.0 <5'
   lodash@>=4.0.0 <=4.17.23: '>=4.18.0'
   minimatch@>=10.0.0 <10.2.3: '>=10.2.3'
   picomatch@<2.3.2: 2.3.2


### PR DESCRIPTION
Resolves https://github.com/equinor/fmu-settings-gui/security/dependabot

Updated the overrides for `brace-expansion` and `js-yaml`. Other alerts will be resolved after we update the `@hey-api/openapi-ts` via this PR https://github.com/equinor/fmu-settings-gui/pull/485. [PR #484](https://github.com/equinor/fmu-settings-gui/pull/484) will also remove the vulnerable `brace-expansion` 1.x path through the ESLint 10 upgrade.

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
